### PR TITLE
Add missing setuptools dependency to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(name="magic-wormhole-mailbox-server",
           "attrs >= 16.3.0", # 16.3.0 adds __attrs_post_init__
           "twisted[tls] >= 17.5.0",
           "autobahn[twisted] >= 0.14.1",
+          "setuptools", # pkg_resources
       ],
       extras_require={
           ':sys_platform=="win32"': ["pywin32"],


### PR DESCRIPTION
Setuptools is a runtime dependency due to this [pkg_resources import](https://github.com/magic-wormhole/magic-wormhole-mailbox-server/blob/0.5.0/src/wormhole_mailbox_server/database.py#L5) and thus should be added to `install_requires`.