### PR TITLE
Synchronize supported versions in README with what is tested in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ wormhole --relay-url=ws://localhost:4000/v1 send FILENAME
 
 This library is released under the MIT license, see LICENSE for details.
 
-This library is compatible with python2.7, and python3 (3.5 and higher).
+This library is compatible with python3 (3.7 and higher).


### PR DESCRIPTION
Python 2.7 was explicitly dropped last year, so probably it makes sense to not mention it in README.