### PR TITLE
Remove uses of twisted.internet.defer.returnValue

### DIFF
--- a/src/wormhole_mailbox_server/test/test_web.py
+++ b/src/wormhole_mailbox_server/test/test_web.py
@@ -4,7 +4,7 @@ from unittest import mock
 import treq
 from twisted.trial import unittest
 from twisted.internet import defer, reactor
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from ..web import make_web_server
 from ..server import SidedMessage
 from ..database import create_or_upgrade_usage_db
@@ -38,7 +38,7 @@ class LogRequests(ServerBase, unittest.TestCase):
         reactor.connectTCP("127.0.0.1", self.rdv_ws_port, f)
         c = yield f.d
         self._clients.append(c)
-        returnValue(c)
+        return c
 
     @inlineCallbacks
     def test_log_http(self):
@@ -108,7 +108,7 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         reactor.connectTCP("127.0.0.1", self.rdv_ws_port, f)
         c = yield f.d
         self._clients.append(c)
-        returnValue(c)
+        return c
 
     def check_welcome(self, data):
         self.failUnlessIn("welcome", data)

--- a/src/wormhole_mailbox_server/test/ws_client.py
+++ b/src/wormhole_mailbox_server/test/ws_client.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, unicode_literals
 import json, itertools
 from twisted.internet import defer
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from autobahn.twisted import websocket
 
 class WSClient(websocket.WebSocketClientProtocol):
@@ -49,7 +49,7 @@ class WSClient(websocket.WebSocketClientProtocol):
                 print("unexpected onClose", m)
                 raise AssertionError("unexpected onClose")
             if m["type"] != "ack":
-                returnValue(m)
+                return m
 
     def strip_acks(self):
         self.events = [e for e in self.events if e["type"] != "ack"]
@@ -73,7 +73,7 @@ class WSClient(websocket.WebSocketClientProtocol):
             ev = yield self.next_event()
             if ev["type"] == "pong" and ev["pong"] == ping:
                 self.events = old_events + self.events
-                returnValue(None)
+                return None
             old_events.append(ev)
 
 class WSFactory(websocket.WebSocketClientFactory):


### PR DESCRIPTION
returnValue() can be replaced with plain return in Python 3 code. returnValue() has been deprecated in Twisted 24.7.0 and will be removed soon.