### PR TITLE
refactoring: use classes directly instead of type() calls

### DIFF
--- a/src/wormhole_mailbox_server/server.py
+++ b/src/wormhole_mailbox_server/server.py
@@ -33,7 +33,7 @@ class Mailbox:
 
     def open(self, side, when):
         # requires caller to db.commit()
-        assert isinstance(side, type("")), type(side)
+        assert isinstance(side, str), type(side)
         db = self._db
 
         already = db.execute("SELECT * FROM `mailbox_sides`"
@@ -115,7 +115,7 @@ class Mailbox:
         self.broadcast_message(sm)
 
     def close(self, side, mood, when):
-        assert isinstance(side, type("")), type(side)
+        assert isinstance(side, str), type(side)
         db = self._db
         row = db.execute("SELECT * FROM `mailboxes`"
                          " WHERE `app_id`=? AND `id`=?",
@@ -243,8 +243,8 @@ class AppNamespace(object):
         #  * there will be one 'side' attached to it, with claimed=True
         # * a mailbox id and mailbox row will be created
         #  * a mailbox 'side' will be attached, with opened=True
-        assert isinstance(name, type("")), type(name)
-        assert isinstance(side, type("")), type(side)
+        assert isinstance(name, str), type(name)
+        assert isinstance(side, str), type(side)
         db = self._db
         row = db.execute("SELECT * FROM `nameplates`"
                          " WHERE `app_id`=? AND `name`=?",
@@ -294,8 +294,8 @@ class AppNamespace(object):
         #  * a usage record will be added
         #  * the nameplate row will be removed
         #  * the nameplate sides will be removed
-        assert isinstance(name, type("")), type(name)
-        assert isinstance(side, type("")), type(side)
+        assert isinstance(name, str), type(name)
+        assert isinstance(side, str), type(side)
         db = self._db
         np_row = db.execute("SELECT * FROM `nameplates`"
                             " WHERE `app_id`=? AND `name`=?",
@@ -359,7 +359,7 @@ class AppNamespace(object):
                      total_time=total_time, result=result)
 
     def _add_mailbox(self, mailbox_id, for_nameplate, side, when):
-        assert isinstance(mailbox_id, type("")), type(mailbox_id)
+        assert isinstance(mailbox_id, str), type(mailbox_id)
         db = self._db
         row = db.execute("SELECT * FROM `mailboxes`"
                          " WHERE `app_id`=? AND `id`=?",
@@ -373,7 +373,7 @@ class AppNamespace(object):
             # does SELECT FROM `mailbox_sides`, not from `mailboxes`
 
     def open_mailbox(self, mailbox_id, side, when):
-        assert isinstance(mailbox_id, type("")), type(mailbox_id)
+        assert isinstance(mailbox_id, str), type(mailbox_id)
         self._add_mailbox(mailbox_id, False, side, when) # ensure row exists
         db = self._db
         if not mailbox_id in self._mailboxes: # ensure Mailbox object exists
@@ -570,7 +570,7 @@ class Server(service.MultiService):
         return self._log_requests
 
     def get_app(self, app_id):
-        assert isinstance(app_id, type(""))
+        assert isinstance(app_id, str)
         if not app_id in self._apps:
             if self._log_requests:
                 log.msg("spawning app_id %s" % (app_id,))

--- a/src/wormhole_mailbox_server/server_websocket.py
+++ b/src/wormhole_mailbox_server/server_websocket.py
@@ -186,7 +186,7 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
         if self._did_allocate:
             raise Error("you already allocated one, don't be greedy")
         nameplate_id = self._app.allocate_nameplate(self._side, server_rx)
-        assert isinstance(nameplate_id, type(""))
+        assert isinstance(nameplate_id, str)
         self._did_allocate = True
         self.send("allocated", nameplate=nameplate_id)
 
@@ -197,7 +197,7 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
             raise Error("only one claim per connection")
         self._did_claim = True
         nameplate_id = msg["nameplate"]
-        assert isinstance(nameplate_id, type("")), type(nameplate_id)
+        assert isinstance(nameplate_id, str), type(nameplate_id)
         self._nameplate_id = nameplate_id
         try:
             mailbox_id = self._app.claim_nameplate(nameplate_id, self._side,
@@ -232,7 +232,7 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
         if "mailbox" not in msg:
             raise Error("open requires 'mailbox'")
         mailbox_id = msg["mailbox"]
-        assert isinstance(mailbox_id, type(""))
+        assert isinstance(mailbox_id, str)
         self._mailbox_id = mailbox_id
         try:
             self._mailbox = self._app.open_mailbox(mailbox_id, self._side,

--- a/src/wormhole_mailbox_server/test/test_server.py
+++ b/src/wormhole_mailbox_server/test/test_server.py
@@ -21,7 +21,7 @@ class Server(_Util, ServerBase, unittest.TestCase):
         # this takes a second, and claims all the short-numbered nameplates
         def add():
             nameplate_id = app.allocate_nameplate("side1", 0)
-            self.assertEqual(type(nameplate_id), type(""))
+            self.assertEqual(type(nameplate_id), str)
             nid = int(nameplate_id)
             nids.add(nid)
         for i in range(9): add()
@@ -55,7 +55,7 @@ class Server(_Util, ServerBase, unittest.TestCase):
     def test_nameplate(self):
         app = self._server.get_app("appid")
         name = app.allocate_nameplate("side1", 0)
-        self.assertEqual(type(name), type(""))
+        self.assertEqual(type(name), str)
         nid = int(name)
         self.assert_(0 < nid < 10, nid)
         self.assertEqual(app.get_nameplate_ids(), set([name]))
@@ -67,7 +67,7 @@ class Server(_Util, ServerBase, unittest.TestCase):
 
         # duplicate claims by the same side are combined
         mailbox_id = app.claim_nameplate(name, "side1", 1)
-        self.assertEqual(type(mailbox_id), type(""))
+        self.assertEqual(type(mailbox_id), str)
         self.assertEqual(mailbox_id, np_row["mailbox_id"])
         np_row, side_rows = self._nameplate(app, name)
         self.assertEqual(len(side_rows), 1)

--- a/src/wormhole_mailbox_server/test/test_util.py
+++ b/src/wormhole_mailbox_server/test/test_util.py
@@ -6,31 +6,31 @@ from .. import util
 class Utils(unittest.TestCase):
     def test_to_bytes(self):
         b = util.to_bytes("abc")
-        self.assertIsInstance(b, type(b""))
+        self.assertIsInstance(b, bytes)
         self.assertEqual(b, b"abc")
 
         A = unicodedata.lookup("LATIN SMALL LETTER A WITH DIAERESIS")
         b = util.to_bytes(A + "bc")
-        self.assertIsInstance(b, type(b""))
+        self.assertIsInstance(b, bytes)
         self.assertEqual(b, b"\xc3\xa4\x62\x63")
 
     def test_bytes_to_hexstr(self):
         b = b"\x00\x45\x91\xfe\xff"
         hexstr = util.bytes_to_hexstr(b)
-        self.assertIsInstance(hexstr, type(""))
+        self.assertIsInstance(hexstr, str)
         self.assertEqual(hexstr, "004591feff")
 
     def test_hexstr_to_bytes(self):
         hexstr = "004591feff"
         b = util.hexstr_to_bytes(hexstr)
         hexstr = util.bytes_to_hexstr(b)
-        self.assertIsInstance(b, type(b""))
+        self.assertIsInstance(b, bytes)
         self.assertEqual(b, b"\x00\x45\x91\xfe\xff")
 
     def test_dict_to_bytes(self):
         d = {"a": "b"}
         b = util.dict_to_bytes(d)
-        self.assertIsInstance(b, type(b""))
+        self.assertIsInstance(b, bytes)
         self.assertEqual(b, b'{"a": "b"}')
 
     def test_bytes_to_dict(self):

--- a/src/wormhole_mailbox_server/test/test_web.py
+++ b/src/wormhole_mailbox_server/test/test_web.py
@@ -284,7 +284,7 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         m = yield c1.next_non_ack()
         self.assertEqual(m["type"], "claimed")
         mailbox_id = m["mailbox"]
-        self.assertEqual(type(mailbox_id), type(""))
+        self.assertEqual(type(mailbox_id), str)
 
         c1.send("claim", nameplate="np1")
         err = yield c1.next_non_ack()
@@ -596,7 +596,7 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         m = yield c.next_non_ack()
         self.assertEqual(m["type"], "claimed")
         mailbox_id = m["mailbox"]
-        self.assertEqual(type(mailbox_id), type(""))
+        self.assertEqual(type(mailbox_id), str)
         np_row, side_rows = self._nameplate(app, "np1")
         claims = [(row["side"], row["claimed"]) for row in side_rows]
         self.assertEqual(claims, [("side", True)])

--- a/src/wormhole_mailbox_server/util.py
+++ b/src/wormhole_mailbox_server/util.py
@@ -5,22 +5,22 @@ from binascii import hexlify, unhexlify
 def to_bytes(u):
     return unicodedata.normalize("NFC", u).encode("utf-8")
 def bytes_to_hexstr(b):
-    assert isinstance(b, type(b""))
+    assert isinstance(b, bytes)
     hexstr = hexlify(b).decode("ascii")
     assert isinstance(hexstr, type(u""))
     return hexstr
 def hexstr_to_bytes(hexstr):
     assert isinstance(hexstr, type(u""))
     b = unhexlify(hexstr.encode("ascii"))
-    assert isinstance(b, type(b""))
+    assert isinstance(b, bytes)
     return b
 def dict_to_bytes(d):
     assert isinstance(d, dict)
     b = json.dumps(d).encode("utf-8")
-    assert isinstance(b, type(b""))
+    assert isinstance(b, bytes)
     return b
 def bytes_to_dict(b):
-    assert isinstance(b, type(b""))
+    assert isinstance(b, bytes)
     d = json.loads(b.decode("utf-8"))
     assert isinstance(d, dict)
     return d


### PR DESCRIPTION
It's an equivalent to PR https://github.com/magic-wormhole/magic-wormhole/pull/637.