### PR TITLE
fix: remove syntax warnings

### DIFF
--- a/src/wormhole_mailbox_server/server_tap.py
+++ b/src/wormhole_mailbox_server/server_tap.py
@@ -19,7 +19,7 @@ class Options(usage.Options):
     longdesc = LONGDESC
 
     optParameters = [
-        ("port", "p", "tcp:4000:interface=\:\:", "endpoint to listen on"),
+        ("port", "p", r"tcp:4000:interface=\:\:", "endpoint to listen on"),
         ("blur-usage", None, None, "round logged access times to improve privacy"),
         ("log-fd", None, None, "write JSON usage logs to this file descriptor"),
         ("channel-db", None, "relay.sqlite", "location for the state database"),

--- a/src/wormhole_mailbox_server/test/test_config.py
+++ b/src/wormhole_mailbox_server/test/test_config.py
@@ -3,7 +3,7 @@ from twisted.python.usage import UsageError
 from twisted.trial import unittest
 from .. import server_tap
 
-PORT = "tcp:4000:interface=\:\:"
+PORT = r"tcp:4000:interface=\:\:"
 
 class Config(unittest.TestCase):
     def test_defaults(self):


### PR DESCRIPTION
Use raw strings to remove invalid escape sequence warnings. For example (at least) in python 3.13:

```
src/wormhole_mailbox_server/server_tap.py:22: SyntaxWarning: invalid escape sequence '\:'
  ("port", "p", "tcp:4000:interface=\:\:", "endpoint to listen on"),
```