### PR TITLE
refactoring: replace formatted strings by f-strings

### DIFF
--- a/src/wormhole_mailbox_server/_version.py
+++ b/src/wormhole_mailbox_server/_version.py
@@ -109,18 +109,18 @@ def run_command(
             if e.errno == errno.ENOENT:
                 continue
             if verbose:
-                print("unable to run %s" % dispcmd)
+                print(f"unable to run {dispcmd}")
                 print(e)
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print(f"unable to find command, tried {commands}")
         return None, None
     stdout = process.communicate()[0].strip().decode()
     if process.returncode != 0:
         if verbose:
-            print("unable to run %s (error)" % dispcmd)
-            print("stdout was %s" % stdout)
+            print(f"unable to run {dispcmd} (error)")
+            print(f"stdout was {stdout}")
         return None, process.returncode
     return stdout, process.returncode
 
@@ -223,9 +223,9 @@ def git_versions_from_keywords(
         # "stabilization", as well as "HEAD" and "master".
         tags = {r for r in refs if re.search(r'\d', r)}
         if verbose:
-            print("discarding '%s', no digits" % ",".join(refs - tags))
+            print(f"discarding '{','.join(refs - tags)}', no digits")
     if verbose:
-        print("likely tags: %s" % ",".join(sorted(tags)))
+        print(f"likely tags: {','.join(sorted(tags))}")
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
@@ -236,7 +236,7 @@ def git_versions_from_keywords(
             if not re.match(r'\d', r):
                 continue
             if verbose:
-                print("picking %s" % r)
+                print(f"picking {r}")
             return {"version": r,
                     "full-revisionid": keywords["full"].strip(),
                     "dirty": False, "error": None,
@@ -277,7 +277,7 @@ def git_pieces_from_vcs(
                    hide_stderr=not verbose)
     if rc != 0:
         if verbose:
-            print("Directory %s not under git control" % root)
+            print(f"Directory {root} not under git control")
         raise NotThisMethod("'git rev-parse --git-dir' returned error")
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
@@ -350,8 +350,7 @@ def git_pieces_from_vcs(
         mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
         if not mo:
             # unparsable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = f"unable to parse git-describe output: '{describe_out}'"
             return pieces
 
         # tag
@@ -500,13 +499,13 @@ def render_pep440_post(pieces: Dict[str, Any]) -> str:
             if pieces["dirty"]:
                 rendered += ".dev0"
             rendered += plus_or_dot(pieces)
-            rendered += "g%s" % pieces["short"]
+            rendered += f"g{pieces['short']}"
     else:
         # exception #1
         rendered = "0.post%d" % pieces["distance"]
         if pieces["dirty"]:
             rendered += ".dev0"
-        rendered += "+g%s" % pieces["short"]
+        rendered += f"+g{pieces['short']}"
     return rendered
 
 
@@ -525,7 +524,7 @@ def render_pep440_post_branch(pieces: Dict[str, Any]) -> str:
             if pieces["branch"] != "master":
                 rendered += ".dev0"
             rendered += plus_or_dot(pieces)
-            rendered += "g%s" % pieces["short"]
+            rendered += f"g{pieces['short']}"
             if pieces["dirty"]:
                 rendered += ".dirty"
     else:
@@ -533,7 +532,7 @@ def render_pep440_post_branch(pieces: Dict[str, Any]) -> str:
         rendered = "0.post%d" % pieces["distance"]
         if pieces["branch"] != "master":
             rendered += ".dev0"
-        rendered += "+g%s" % pieces["short"]
+        rendered += f"+g{pieces['short']}"
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -630,7 +629,7 @@ def render(pieces: Dict[str, Any], style: str) -> Dict[str, Any]:
     elif style == "git-describe-long":
         rendered = render_git_describe_long(pieces)
     else:
-        raise ValueError("unknown style '%s'" % style)
+        raise ValueError(f"unknown style '{style}'")
 
     return {"version": rendered, "full-revisionid": pieces["long"],
             "dirty": pieces["dirty"], "error": None,

--- a/src/wormhole_mailbox_server/database.py
+++ b/src/wormhole_mailbox_server/database.py
@@ -34,7 +34,7 @@ def dict_factory(cursor, row):
 def _initialize_db_schema(db, name, target_version):
     """Creates the application schema in the given database.
     """
-    log.msg("populating new database with schema %s v%s" % (name, target_version))
+    log.msg(f"populating new database with schema {name} v{target_version}")
     schema = get_schema(name, target_version)
     db.executescript(schema)
     db.execute("INSERT INTO version (version) VALUES (?)",
@@ -49,7 +49,7 @@ def _initialize_db_connection(db):
     db.execute("PRAGMA foreign_keys = ON")
     problems = db.execute("PRAGMA foreign_key_check").fetchall()
     if problems:
-        raise DBError("failed foreign key check: %s" % (problems,))
+        raise DBError(f"failed foreign key check: {problems}")
 
 def _open_db_connection(dbfile):
     """Open a new connection to the SQLite3 database at the given path.
@@ -60,7 +60,7 @@ def _open_db_connection(dbfile):
     except (EnvironmentError, sqlite3.OperationalError, sqlite3.DatabaseError) as e:
         # this indicates that the file is not a compatible database format.
         # Perhaps it was created with an old version, or it might be junk.
-        raise DBError("Unable to create/open db file %s: %s" % (dbfile, e))
+        raise DBError(f"Unable to create/open db file {dbfile}: {e}")
     return db
 
 def _get_temporary_dbfile(dbfile):
@@ -106,20 +106,20 @@ def _get_db(dbfile, name, target_version):
         shutil.copy(dbfile, backup_fn)
 
     while version < target_version:
-        log.msg(" need to upgrade from %s to %s" % (version, target_version))
+        log.msg(f" need to upgrade from {version} to {target_version}")
         try:
             upgrader = get_upgrader(name, version+1)
         except ValueError:
-            log.msg(" unable to upgrade %s to %s" % (version, version+1))
+            log.msg(f" unable to upgrade {version} to {version + 1}")
             raise DBError("Unable to upgrade %s to version %s, left at %s"
                           % (dbfile, version+1, version))
-        log.msg(" executing upgrader v%s->v%s" % (version, version+1))
+        log.msg(f" executing upgrader v{version}->v{version + 1}")
         db.executescript(upgrader)
         db.commit()
         version = version+1
 
     if version != target_version:
-        raise DBError("Unable to handle db version %s" % version)
+        raise DBError(f"Unable to handle db version {version}")
 
     return db
 

--- a/src/wormhole_mailbox_server/increase_rlimits.py
+++ b/src/wormhole_mailbox_server/increase_rlimits.py
@@ -19,14 +19,13 @@ def increase_rlimits():
     # soft=hard. Cygwin is reported to return (256,-1) and accepts up to
     # soft=3200. So we try multiple values until something works.
     for newlimit in [hard, 10000, 3200, 1024]:
-        log.msg("changing RLIMIT_NOFILE from (%s,%s) to (%s,%s)" %
-                (soft, hard, newlimit, hard))
+        log.msg(f"changing RLIMIT_NOFILE from ({soft},{hard}) to ({newlimit},{hard})")
         try:
             setrlimit(RLIMIT_NOFILE, (newlimit, hard))
             log.msg("setrlimit successful")
             return
         except ValueError as e:
-            log.msg("error during setrlimit: %s" % e)
+            log.msg(f"error during setrlimit: {e}")
             continue
         except:
             log.msg("other error during setrlimit, leaving it alone")

--- a/src/wormhole_mailbox_server/server.py
+++ b/src/wormhole_mailbox_server/server.py
@@ -251,8 +251,7 @@ class AppNamespace(object):
                          (self._app_id, name)).fetchone()
         if not row:
             if self._log_requests:
-                log.msg("creating nameplate#%s for app_id %s" %
-                        (name, self._app_id))
+                log.msg(f"creating nameplate#{name} for app_id {self._app_id}")
             mailbox_id = generate_mailbox_id()
             self._add_mailbox(mailbox_id, True, side, when) # ensure row exists
             sql = ("INSERT INTO `nameplates`"
@@ -378,8 +377,7 @@ class AppNamespace(object):
         db = self._db
         if not mailbox_id in self._mailboxes: # ensure Mailbox object exists
             if self._log_requests:
-                log.msg("spawning #%s for app_id %s" % (mailbox_id,
-                                                        self._app_id))
+                log.msg(f"spawning #{mailbox_id} for app_id {self._app_id}")
             self._mailboxes[mailbox_id] = Mailbox(self,
                                                   self._db, self._usage_db,
                                                   self._app_id, mailbox_id)
@@ -468,13 +466,13 @@ class AppNamespace(object):
         # instead of by user action. It does reveal which mailboxes were
         # present when the pruning process began, though, so in the log run
         # it should do less logging.
-        log.msg(" prune begins (%s)" % self._app_id)
+        log.msg(f" prune begins ({self._app_id})")
         db = self._db
         modified = False
 
         for mailbox in self._mailboxes.values():
             if mailbox.has_listeners():
-                log.msg("touch %s because listeners" % mailbox._mailbox_id)
+                log.msg(f"touch {mailbox._mailbox_id} because listeners")
                 mailbox._touch(now)
         db.commit() # make sure the updates are visible below
 
@@ -483,8 +481,7 @@ class AppNamespace(object):
         for row in db.execute("SELECT * FROM `mailboxes` WHERE `app_id`=?",
                               (self._app_id,)).fetchall():
             mailbox_id = row["id"]
-            log.msg("  1: age=%s, old=%s, %s" %
-                    (now - row["updated"], now - old, mailbox_id))
+            log.msg(f"  1: age={now - row['updated']}, old={now - old}, {mailbox_id}")
             if row["updated"] > old:
                 new_mailboxes.add(mailbox_id)
             else:
@@ -539,7 +536,7 @@ class AppNamespace(object):
             if self._usage_db:
                 self._usage_db.commit()
         in_use = bool(self._mailboxes)
-        log.msg("  prune complete, modified=%s, in_use=%s" % (modified, in_use))
+        log.msg(f"  prune complete, modified={modified}, in_use={in_use}")
         return in_use
 
     def count_listeners(self):
@@ -573,7 +570,7 @@ class Server(service.MultiService):
         assert isinstance(app_id, str)
         if not app_id in self._apps:
             if self._log_requests:
-                log.msg("spawning app_id %s" % (app_id,))
+                log.msg(f"spawning app_id {app_id}")
             self._apps[app_id] = AppNamespace(
                 self._db,
                 self._usage_db,
@@ -601,12 +598,12 @@ class Server(service.MultiService):
         # As with AppNamespace.prune_old_mailboxes, we log for now.
         log.msg("beginning app prune")
         for app_id in sorted(self.get_all_apps()):
-            log.msg(" app prune checking %r" % (app_id,))
+            log.msg(f" app prune checking {app_id!r}")
             app = self.get_app(app_id)
             in_use = app.prune(now, old)
             if not in_use:
                 del self._apps[app_id]
-        log.msg("app prune ends, %d apps" % len(self._apps))
+        log.msg(f"app prune ends, {len(self._apps)} apps")
 
     def dump_stats(self, now, rebooted):
         if not self._usage_db:

--- a/src/wormhole_mailbox_server/server_tap.py
+++ b/src/wormhole_mailbox_server/server_tap.py
@@ -57,7 +57,7 @@ class Options(usage.Options):
         try:
             value = json.loads(value)
         except:
-            raise usage.UsageError("could not parse JSON value for {}".format(key))
+            raise usage.UsageError(f"could not parse JSON value for {key}")
         self["websocket-protocol-options"].append((key, value))
 
 

--- a/src/wormhole_mailbox_server/server_websocket.py
+++ b/src/wormhole_mailbox_server/server_websocket.py
@@ -113,7 +113,7 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
     def onConnect(self, request):
         rv = self.factory.server
         if rv.get_log_requests():
-            log.msg("ws client connecting: %s" % (request.peer,))
+            log.msg(f"ws client connecting: {request.peer}")
         self._reactor = self.factory.reactor
 
     def onOpen(self):


### PR DESCRIPTION
The change has been generated by [flynt tool](https://github.com/ikamensh/flynt).

`tox` is green (tested only with python3.13 which is not officially supported).