### PR TITLE
fix: test: force same stdout output by env var

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,9 @@ usedevelop = True
 extras = dev
 deps =
     pyflakes >= 1.2.3
+setenv =
+    # set COLUMNS to standardize string output
+    COLUMNS=80
 commands =
     pyflakes setup.py src
     python -m twisted.trial {posargs:wormhole_mailbox_server}


### PR DESCRIPTION
The assertion failed because a string was not exactly matched because '\n' and spaces were inserted between words. It's done by inherited `twisted.python.usage.Options()` to print a pretty output for the user according to the width of the terminal.

Setting `$COLUMN` variable environment for the tests with a classical value (80) fixes the error because the sentence is only on one line (so it matches the assertion).

The fixed assertion:
```
src/wormhole_mailbox_server/test/test_config.py", line 219, in test_string
    self.assertIn("round logged access times to improve privacy", s)
```