### PR TITLE
require nameplates to be all-numeric and not too long

### DIFF
--- a/src/wormhole_mailbox_server/server.py
+++ b/src/wormhole_mailbox_server/server.py
@@ -1,10 +1,20 @@
-import os, random, base64
+import os, random, base64, re
 from collections import namedtuple
 from twisted.python import log
 from twisted.application import service
 
 def generate_mailbox_id():
     return base64.b32encode(os.urandom(8)).lower().strip(b"=").decode("ascii")
+
+NAMEPLATE_RE = re.compile(r'^\d+$')
+
+def check_valid_nameplate(n):
+    if not isinstance(n, str):
+        raise ValueError("nameplate %r is %s not str" % (n, type(n)))
+    if len(n) > 40:
+        raise ValueError("nameplate %s .. is too long, %d>40" % (repr(n)[:50], len(n)))
+    if not NAMEPLATE_RE.search(n):
+        raise ValueError("nameplate %s has non-digits" % (n,))
 
 class CrowdedError(Exception):
     pass
@@ -244,6 +254,7 @@ class AppNamespace:
         #  * a mailbox 'side' will be attached, with opened=True
         assert isinstance(name, str), type(name)
         assert isinstance(side, str), type(side)
+        check_valid_nameplate(name)
         db = self._db
         row = db.execute("SELECT * FROM `nameplates`"
                          " WHERE `app_id`=? AND `name`=?",

--- a/src/wormhole_mailbox_server/server_websocket.py
+++ b/src/wormhole_mailbox_server/server_websocket.py
@@ -2,7 +2,7 @@ import time
 from twisted.internet import reactor
 from twisted.python import log
 from autobahn.twisted import websocket
-from .server import CrowdedError, ReclaimedError, SidedMessage
+from .server import CrowdedError, ReclaimedError, SidedMessage, check_valid_nameplate
 from .util import dict_to_bytes, bytes_to_dict
 
 # The WebSocket allows the client to send "commands" to the server, and the
@@ -196,7 +196,7 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
             raise Error("only one claim per connection")
         self._did_claim = True
         nameplate_id = msg["nameplate"]
-        assert isinstance(nameplate_id, str), type(nameplate_id)
+        check_valid_nameplate(nameplate_id)
         self._nameplate_id = nameplate_id
         try:
             mailbox_id = self._app.claim_nameplate(nameplate_id, self._side,
@@ -212,6 +212,8 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
             raise Error("only one release per connection")
         if "nameplate" in msg:
             if self._nameplate_id is not None:
+                # we only care about equality, don't bother with
+                # check_valid_nameplate()
                 if msg["nameplate"] != self._nameplate_id:
                     raise Error("release and claim must use same nameplate")
             nameplate_id = msg["nameplate"]

--- a/src/wormhole_mailbox_server/test/test_server.py
+++ b/src/wormhole_mailbox_server/test/test_server.py
@@ -6,6 +6,7 @@ from ..server import (make_server, Usage,
                       SidedMessage, CrowdedError, AppNamespace)
 from ..database import create_channel_db, create_usage_db
 
+npid = "1"
 
 class Server(_Util, ServerBase, unittest.TestCase):
     def test_apps(self):
@@ -323,17 +324,17 @@ class Prune(unittest.TestCase):
         app = rv.get_app(APPID)
 
         # Exercise the first-vs-second newness tests
-        app.claim_nameplate("np-1", "side1", 1)
-        app.claim_nameplate("np-2", "side1", 1)
-        app.claim_nameplate("np-2", "side2", 2)
-        app.claim_nameplate("np-3", "side1", 60)
-        new_nameplates.add("np-3")
-        app.claim_nameplate("np-4", "side1", 1)
-        app.claim_nameplate("np-4", "side2", 60)
-        new_nameplates.add("np-4")
-        app.claim_nameplate("np-5", "side1", 60)
-        app.claim_nameplate("np-5", "side2", 61)
-        new_nameplates.add("np-5")
+        app.claim_nameplate("1", "side1", 1)
+        app.claim_nameplate("2", "side1", 1)
+        app.claim_nameplate("2", "side2", 2)
+        app.claim_nameplate("3", "side1", 60)
+        new_nameplates.add("3")
+        app.claim_nameplate("4", "side1", 1)
+        app.claim_nameplate("4", "side2", 60)
+        new_nameplates.add("4")
+        app.claim_nameplate("5", "side1", 60)
+        app.claim_nameplate("5", "side2", 61)
+        new_nameplates.add("5")
 
         rv.prune_all_apps(now=123, old=50)
 
@@ -404,7 +405,7 @@ class Prune(unittest.TestCase):
 
         mbid = "mbid"
         if nameplate:
-            mbid = app.claim_nameplate("npid", "side1", when[mailbox])
+            mbid = app.claim_nameplate(npid, "side1", when[mailbox])
         mb = app.open_mailbox(mbid, "side1", when[mailbox])
 
         # the pruning algorithm doesn't care about the age of messages,
@@ -519,7 +520,7 @@ class Summary(unittest.TestCase):
         rv = make_server(db, blur_usage=3600, usage_db=usage_db)
         APPID = "appid"
         app = rv.get_app(APPID)
-        app.claim_nameplate("npid", "side1", 10) # start time is 10
+        app.claim_nameplate(npid, "side1", 10) # start time is 10
         rv.prune_all_apps(now=123, old=50)
         # start time should be rounded to top of the hour (blur_usage=3600)
         row = usage_db.execute("SELECT * FROM `nameplates`").fetchone()
@@ -537,7 +538,7 @@ class Summary(unittest.TestCase):
         rv = make_server(db, blur_usage=None, usage_db=usage_db)
         APPID = "appid"
         app = rv.get_app(APPID)
-        app.claim_nameplate("npid", "side1", 10) # start time is 10
+        app.claim_nameplate(npid, "side1", 10) # start time is 10
         rv.prune_all_apps(now=123, old=50)
         row = usage_db.execute("SELECT * FROM `nameplates`").fetchone()
         self.assertEqual(row["started"], 10)

--- a/src/wormhole_mailbox_server/test/test_server.py
+++ b/src/wormhole_mailbox_server/test/test_server.py
@@ -345,6 +345,14 @@ class Prune(unittest.TestCase):
                          db.execute("SELECT * FROM `mailboxes`").fetchall()}
         self.assertEqual(len(new_nameplates), len(mailboxes))
 
+        self.assertRaises(ValueError,
+                          app.claim_nameplate, "letters", "side1", 1)
+        long_but_ok = "1234"*10
+        app.claim_nameplate(long_but_ok, "side1", 1)
+        too_long = long_but_ok + "5"
+        self.assertRaises(ValueError,
+                          app.claim_nameplate, too_long, "side1", 1)
+
     def test_mailboxes(self):
         db = create_channel_db(":memory:")
         rv = make_server(db, blur_usage=3600)

--- a/src/wormhole_mailbox_server/test/test_stats.py
+++ b/src/wormhole_mailbox_server/test/test_stats.py
@@ -3,6 +3,8 @@ from twisted.trial import unittest
 from ..database import create_channel_db, create_usage_db
 from ..server import make_server, CrowdedError
 
+np1 = "1"
+
 class _Make:
     def make(self, blur_usage=None, with_usage_db=True):
         self._cdb = create_channel_db(":memory:")
@@ -68,27 +70,27 @@ class ClientVersion(_Make, unittest.TestCase):
 class Nameplate(_Make, unittest.TestCase):
     def test_nameplate_happy(self):
         s, db, app = self.make()
-        app.claim_nameplate("n1", "s1", 1)
-        app.claim_nameplate("n1", "s2", 3)
-        app.release_nameplate("n1", "s1", 6)
+        app.claim_nameplate(np1, "s1", 1)
+        app.claim_nameplate(np1, "s2", 3)
+        app.release_nameplate(np1, "s1", 6)
         self.assertEqual(db.execute("SELECT * FROM `nameplates`").fetchall(),
                          [])
-        app.release_nameplate("n1", "s2", 10)
+        app.release_nameplate(np1, "s2", 10)
         self.assertEqual(db.execute("SELECT * FROM `nameplates`").fetchall(),
                          [dict(app_id="appid", result="happy",
                                started=1, waiting_time=2, total_time=9)])
 
     def test_nameplate_lonely(self):
         s, db, app = self.make()
-        app.claim_nameplate("n1", "s1", 1)
-        app.release_nameplate("n1", "s1", 6)
+        app.claim_nameplate(np1, "s1", 1)
+        app.release_nameplate(np1, "s1", 6)
         self.assertEqual(db.execute("SELECT * FROM `nameplates`").fetchall(),
                          [dict(app_id="appid", result="lonely",
                                started=1, waiting_time=None, total_time=5)])
 
     def test_nameplate_pruney(self):
         s, db, app = self.make()
-        app.claim_nameplate("n1", "s1", 1)
+        app.claim_nameplate(np1, "s1", 1)
         app.prune(10, 5) # prune at t=10, anything earlier than 5 is "old"
         self.assertEqual(db.execute("SELECT * FROM `nameplates`").fetchall(),
                          [dict(app_id="appid", result="pruney",
@@ -96,16 +98,16 @@ class Nameplate(_Make, unittest.TestCase):
 
     def test_nameplate_crowded(self):
         s, db, app = self.make()
-        app.claim_nameplate("n1", "s1", 1)
-        app.claim_nameplate("n1", "s2", 2)
+        app.claim_nameplate(np1, "s1", 1)
+        app.claim_nameplate(np1, "s2", 2)
         with self.assertRaises(CrowdedError):
-            app.claim_nameplate("n1", "s3", 3)
+            app.claim_nameplate(np1, "s3", 3)
         self.assertEqual(db.execute("SELECT * FROM `nameplates`").fetchall(),
                          [])
-        app.release_nameplate("n1", "s1", 4)
+        app.release_nameplate(np1, "s1", 4)
         self.assertEqual(db.execute("SELECT * FROM `nameplates`").fetchall(),
                          [])
-        app.release_nameplate("n1", "s2", 5)
+        app.release_nameplate(np1, "s2", 5)
         self.assertEqual(db.execute("SELECT * FROM `nameplates`").fetchall(),
                          [])
         #print(self._cdb.execute("SELECT * FROM `nameplates`").fetchall())
@@ -113,17 +115,17 @@ class Nameplate(_Make, unittest.TestCase):
         # TODO: to get "crowded", we need all three sides to release the
         # nameplate, even though the third side threw CrowdedError and thus
         # probably doesn't think it has a claim
-        app.release_nameplate("n1", "s3", 6)
+        app.release_nameplate(np1, "s3", 6)
         self.assertEqual(db.execute("SELECT * FROM `nameplates`").fetchall(),
                          [dict(app_id="appid", result="crowded",
                                started=1, waiting_time=1, total_time=5)])
 
     def test_nameplate_crowded_pruned(self):
         s, db, app = self.make()
-        app.claim_nameplate("n1", "s1", 1)
-        app.claim_nameplate("n1", "s2", 2)
+        app.claim_nameplate(np1, "s1", 1)
+        app.claim_nameplate(np1, "s2", 2)
         with self.assertRaises(CrowdedError):
-            app.claim_nameplate("n1", "s3", 3)
+            app.claim_nameplate(np1, "s3", 3)
         self.assertEqual(db.execute("SELECT * FROM `nameplates`").fetchall(),
                          [])
         app.prune(10, 5)
@@ -133,18 +135,18 @@ class Nameplate(_Make, unittest.TestCase):
 
     def test_no_db(self):
         s, db, app = self.make(with_usage_db=False)
-        app.claim_nameplate("n1", "s1", 1)
-        app.release_nameplate("n1", "s1", 6)
+        app.claim_nameplate(np1, "s1", 1)
+        app.release_nameplate(np1, "s1", 6)
         s.dump_stats(3, 1)
 
     def test_nameplate_happy_blur_usage(self):
         s, db, app = self.make(blur_usage=20)
-        app.claim_nameplate("n1", "s1", 21)
-        app.claim_nameplate("n1", "s2", 23)
-        app.release_nameplate("n1", "s1", 26)
+        app.claim_nameplate(np1, "s1", 21)
+        app.claim_nameplate(np1, "s2", 23)
+        app.release_nameplate(np1, "s1", 26)
         self.assertEqual(db.execute("SELECT * FROM `nameplates`").fetchall(),
                          [])
-        app.release_nameplate("n1", "s2", 30)
+        app.release_nameplate(np1, "s2", 30)
         self.assertEqual(db.execute("SELECT * FROM `nameplates`").fetchall(),
                          [dict(app_id="appid", result="happy",
                                started=20, waiting_time=2, total_time=9)])
@@ -152,8 +154,8 @@ class Nameplate(_Make, unittest.TestCase):
 class Mailbox(_Make, unittest.TestCase):
     def test_mailbox_prune_quiet(self):
         s, db, app = self.make()
-        app.claim_nameplate("n1", "s1", 1)
-        app.release_nameplate("n1", "s1", 2)
+        app.claim_nameplate(np1, "s1", 1)
+        app.release_nameplate(np1, "s1", 2)
         app.prune(10, 5)
         self.assertEqual(db.execute("SELECT * FROM `mailboxes`").fetchall(),
                          [dict(app_id="appid", for_nameplate=1, result="pruney",
@@ -161,9 +163,9 @@ class Mailbox(_Make, unittest.TestCase):
 
     def test_mailbox_lonely(self):
         s, db, app = self.make()
-        mid = app.claim_nameplate("n1", "s1", 1)
+        mid = app.claim_nameplate(np1, "s1", 1)
         mbox = app.open_mailbox(mid, "s1", 2)
-        app.release_nameplate("n1", "s1", 3)
+        app.release_nameplate(np1, "s1", 3)
         mbox.close("s1", "mood-ignored", 4)
         self.assertEqual(db.execute("SELECT * FROM `mailboxes`").fetchall(),
                          [dict(app_id="appid", for_nameplate=1, result="lonely",
@@ -171,9 +173,9 @@ class Mailbox(_Make, unittest.TestCase):
 
     def test_mailbox_happy(self):
         s, db, app = self.make()
-        mid = app.claim_nameplate("n1", "s1", 1)
+        mid = app.claim_nameplate(np1, "s1", 1)
         mbox1 = app.open_mailbox(mid, "s1", 2)
-        app.release_nameplate("n1", "s1", 3)
+        app.release_nameplate(np1, "s1", 3)
         mbox2 = app.open_mailbox(mid, "s2", 4)
         mbox1.close("s1", "happy", 5)
         mbox2.close("s2", "happy", 6)
@@ -183,9 +185,9 @@ class Mailbox(_Make, unittest.TestCase):
 
     def test_mailbox_happy_blur_usage(self):
         s, db, app = self.make(blur_usage=20)
-        mid = app.claim_nameplate("n1", "s1", 21)
+        mid = app.claim_nameplate(np1, "s1", 21)
         mbox1 = app.open_mailbox(mid, "s1", 22)
-        app.release_nameplate("n1", "s1", 23)
+        app.release_nameplate(np1, "s1", 23)
         mbox2 = app.open_mailbox(mid, "s2", 24)
         mbox1.close("s1", "happy", 25)
         mbox2.close("s2", "happy", 26)
@@ -198,9 +200,9 @@ class Mailbox(_Make, unittest.TestCase):
         # connect, but then at least one side says they're lonely when they
         # close.
         s, db, app = self.make()
-        mid = app.claim_nameplate("n1", "s1", 1)
+        mid = app.claim_nameplate(np1, "s1", 1)
         mbox1 = app.open_mailbox(mid, "s1", 2)
-        app.release_nameplate("n1", "s1", 3)
+        app.release_nameplate(np1, "s1", 3)
         mbox2 = app.open_mailbox(mid, "s2", 4)
         mbox1.close("s1", "lonely", 5)
         mbox2.close("s2", "happy", 6)
@@ -210,9 +212,9 @@ class Mailbox(_Make, unittest.TestCase):
 
     def test_mailbox_scary(self):
         s, db, app = self.make()
-        mid = app.claim_nameplate("n1", "s1", 1)
+        mid = app.claim_nameplate(np1, "s1", 1)
         mbox1 = app.open_mailbox(mid, "s1", 2)
-        app.release_nameplate("n1", "s1", 3)
+        app.release_nameplate(np1, "s1", 3)
         mbox2 = app.open_mailbox(mid, "s2", 4)
         mbox1.close("s1", "scary", 5)
         mbox2.close("s2", "happy", 6)
@@ -222,9 +224,9 @@ class Mailbox(_Make, unittest.TestCase):
 
     def test_mailbox_errory(self):
         s, db, app = self.make()
-        mid = app.claim_nameplate("n1", "s1", 1)
+        mid = app.claim_nameplate(np1, "s1", 1)
         mbox1 = app.open_mailbox(mid, "s1", 2)
-        app.release_nameplate("n1", "s1", 3)
+        app.release_nameplate(np1, "s1", 3)
         mbox2 = app.open_mailbox(mid, "s2", 4)
         mbox1.close("s1", "errory", 5)
         mbox2.close("s2", "happy", 6)
@@ -234,9 +236,9 @@ class Mailbox(_Make, unittest.TestCase):
 
     def test_mailbox_errory_scary(self):
         s, db, app = self.make()
-        mid = app.claim_nameplate("n1", "s1", 1)
+        mid = app.claim_nameplate(np1, "s1", 1)
         mbox1 = app.open_mailbox(mid, "s1", 2)
-        app.release_nameplate("n1", "s1", 3)
+        app.release_nameplate(np1, "s1", 3)
         mbox2 = app.open_mailbox(mid, "s2", 4)
         mbox1.close("s1", "errory", 5)
         mbox2.close("s2", "scary", 6)
@@ -246,9 +248,9 @@ class Mailbox(_Make, unittest.TestCase):
 
     def test_mailbox_crowded(self):
         s, db, app = self.make()
-        mid = app.claim_nameplate("n1", "s1", 1)
+        mid = app.claim_nameplate(np1, "s1", 1)
         mbox1 = app.open_mailbox(mid, "s1", 2)
-        app.release_nameplate("n1", "s1", 3)
+        app.release_nameplate(np1, "s1", 3)
         mbox2 = app.open_mailbox(mid, "s2", 4)
         with self.assertRaises(CrowdedError):
             app.open_mailbox(mid, "s3", 5)

--- a/src/wormhole_mailbox_server/test/test_web.py
+++ b/src/wormhole_mailbox_server/test/test_web.py
@@ -10,6 +10,9 @@ from ..database import create_or_upgrade_usage_db
 from .common import ServerBase, _Util
 from .ws_client import WSFactory
 
+np1 = "1"
+np2 = "2"
+
 class WebSocketProtocolOptions(unittest.TestCase):
     @mock.patch('wormhole_mailbox_server.web.WebSocketServerFactory')
     def test_set(self, fake_factory):
@@ -222,7 +225,7 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
 
         app = self._server.get_app("appid")
         nameplate_id1 = app.allocate_nameplate("side", 0)
-        app.claim_nameplate("np2", "side", 0)
+        app.claim_nameplate(np2, "side", 0)
 
         c1.send("list")
         m = yield c1.next_non_ack()
@@ -232,7 +235,7 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
             self.assertEqual(type(n), dict)
             self.assertEqual(list(n.keys()), ["id"])
             nids.add(n["id"])
-        self.assertEqual(nids, {nameplate_id1, "np2"})
+        self.assertEqual(nids, {nameplate_id1, np2})
 
     @inlineCallbacks
     def test_allocate(self):
@@ -279,21 +282,21 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         self.assertEqual(err["type"], "error")
         self.assertEqual(err["error"], "claim requires 'nameplate'")
 
-        c1.send("claim", nameplate="np1")
+        c1.send("claim", nameplate=np1)
         m = yield c1.next_non_ack()
         self.assertEqual(m["type"], "claimed")
         mailbox_id = m["mailbox"]
         self.assertEqual(type(mailbox_id), str)
 
-        c1.send("claim", nameplate="np1")
+        c1.send("claim", nameplate=np1)
         err = yield c1.next_non_ack()
         self.assertEqual(err["type"], "error", err)
         self.assertEqual(err["error"], "only one claim per connection")
 
         nids = app.get_nameplate_ids()
         self.assertEqual(len(nids), 1)
-        self.assertEqual("np1", list(nids)[0])
-        np_row, side_rows = self._nameplate(app, "np1")
+        self.assertEqual(np1, list(nids)[0])
+        np_row, side_rows = self._nameplate(app, np1)
         self.assertEqual(len(side_rows), 1)
         self.assertEqual(side_rows[0]["side"], "side")
 
@@ -310,11 +313,11 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         c1.send("bind", appid="appid", side="side")
         app = self._server.get_app("appid")
 
-        app.claim_nameplate("np1", "side1", 0)
-        app.claim_nameplate("np1", "side2", 0)
+        app.claim_nameplate(np1, "side1", 0)
+        app.claim_nameplate(np1, "side2", 0)
 
         # the third claim will signal crowding
-        c1.send("claim", nameplate="np1")
+        c1.send("claim", nameplate=np1)
         err = yield c1.next_non_ack()
         self.assertEqual(err["type"], "error")
         self.assertEqual(err["error"], "crowded")
@@ -326,7 +329,7 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         c1.send("bind", appid="appid", side="side")
         app = self._server.get_app("appid")
 
-        app.claim_nameplate("np1", "side2", 0)
+        app.claim_nameplate(np1, "side2", 0)
 
         c1.send("release") # didn't do claim first
         err = yield c1.next_non_ack()
@@ -334,14 +337,14 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         self.assertEqual(err["error"],
                          "release without nameplate must follow claim")
 
-        c1.send("claim", nameplate="np1")
+        c1.send("claim", nameplate=np1)
         yield c1.next_non_ack()
 
         c1.send("release")
         m = yield c1.next_non_ack()
         self.assertEqual(m["type"], "released", m)
 
-        np_row, side_rows = self._nameplate(app, "np1")
+        np_row, side_rows = self._nameplate(app, np1)
         claims = [(row["side"], row["claimed"]) for row in side_rows]
         self.assertIn(("side", False), claims)
         self.assertIn(("side2", True), claims)
@@ -357,10 +360,10 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         yield c1.next_non_ack()
         c1.send("bind", appid="appid", side="side")
 
-        c1.send("claim", nameplate="np1")
+        c1.send("claim", nameplate=np1)
         yield c1.next_non_ack()
 
-        c1.send("release", nameplate="np1")
+        c1.send("release", nameplate=np1)
         m = yield c1.next_non_ack()
         self.assertEqual(m["type"], "released", m)
 
@@ -370,7 +373,7 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         yield c1.next_non_ack()
         c1.send("bind", appid="appid", side="side")
 
-        c1.send("release", nameplate="np1") # didn't do claim first, ignored
+        c1.send("release", nameplate=np1) # didn't do claim first, ignored
         m = yield c1.next_non_ack()
         self.assertEqual(m["type"], "released", m)
 
@@ -380,10 +383,10 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         yield c1.next_non_ack()
         c1.send("bind", appid="appid", side="side")
 
-        c1.send("claim", nameplate="np1")
+        c1.send("claim", nameplate=np1)
         yield c1.next_non_ack()
 
-        c1.send("release", nameplate="np2") # mismatching nameplate
+        c1.send("release", nameplate=np2) # mismatching nameplate
         err = yield c1.next_non_ack()
         self.assertEqual(err["type"], "error")
         self.assertEqual(err["error"],
@@ -435,8 +438,8 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         c1.send("bind", appid="appid", side="side")
         app = self._server.get_app("appid")
 
-        mbid = app.claim_nameplate("np1", "side1", 0)
-        app.claim_nameplate("np1", "side2", 0)
+        mbid = app.claim_nameplate(np1, "side1", 0)
+        app.claim_nameplate(np1, "side2", 0)
 
         # the third open will signal crowding
         c1.send("open", mailbox=mbid)
@@ -550,8 +553,8 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         c1.send("bind", appid="appid", side="side")
         app = self._server.get_app("appid")
 
-        mbid = app.claim_nameplate("np1", "side1", 0)
-        app.claim_nameplate("np1", "side2", 0)
+        mbid = app.claim_nameplate(np1, "side1", 0)
+        app.claim_nameplate(np1, "side2", 0)
 
         # a close that allocates a third side will signal crowding
         c1.send("close", mailbox=mbid)
@@ -591,12 +594,12 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         c.send("bind", appid="appid", side="side")
         app = self._server.get_app("appid")
 
-        c.send("claim", nameplate="np1")
+        c.send("claim", nameplate=np1)
         m = yield c.next_non_ack()
         self.assertEqual(m["type"], "claimed")
         mailbox_id = m["mailbox"]
         self.assertEqual(type(mailbox_id), str)
-        np_row, side_rows = self._nameplate(app, "np1")
+        np_row, side_rows = self._nameplate(app, np1)
         claims = [(row["side"], row["claimed"]) for row in side_rows]
         self.assertEqual(claims, [("side", True)])
         c.close()
@@ -605,11 +608,11 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         c = yield self.make_client()
         yield c.next_non_ack()
         c.send("bind", appid="appid", side="side")
-        c.send("claim", nameplate="np1") # idempotent
+        c.send("claim", nameplate=np1) # idempotent
         m = yield c.next_non_ack()
         self.assertEqual(m["type"], "claimed")
         self.assertEqual(m["mailbox"], mailbox_id) # mailbox id is stable
-        np_row, side_rows = self._nameplate(app, "np1")
+        np_row, side_rows = self._nameplate(app, np1)
         claims = [(row["side"], row["claimed"]) for row in side_rows]
         self.assertEqual(claims, [("side", True)])
         c.close()
@@ -620,10 +623,10 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         c.send("bind", appid="appid", side="side")
         # we haven't done a claim with this particular connection, but we can
         # still send a release as long as we include the nameplate
-        c.send("release", nameplate="np1") # release-without-claim
+        c.send("release", nameplate=np1) # release-without-claim
         m = yield c.next_non_ack()
         self.assertEqual(m["type"], "released")
-        np_row, side_rows = self._nameplate(app, "np1")
+        np_row, side_rows = self._nameplate(app, np1)
         self.assertEqual(np_row, None)
         c.close()
         yield c.d
@@ -632,10 +635,10 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         yield c.next_non_ack()
         c.send("bind", appid="appid", side="side")
         # and the release is idempotent, when done on separate connections
-        c.send("release", nameplate="np1")
+        c.send("release", nameplate=np1)
         m = yield c.next_non_ack()
         self.assertEqual(m["type"], "released")
-        np_row, side_rows = self._nameplate(app, "np1")
+        np_row, side_rows = self._nameplate(app, np1)
         self.assertEqual(np_row, None)
         c.close()
         yield c.d
@@ -654,14 +657,14 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         c = yield self.make_client()
         yield c.next_non_ack()
         c.send("bind", appid="appid", side="side")
-        c.send("claim", nameplate="np2")
+        c.send("claim", nameplate=np2)
         m = yield c.next_non_ack()
         self.assertEqual(m["type"], "claimed")
-        app.claim_nameplate("np2", "side2", 0)
-        c.send("release", nameplate="np2")
+        app.claim_nameplate(np2, "side2", 0)
+        c.send("release", nameplate=np2)
         m = yield c.next_non_ack()
         self.assertEqual(m["type"], "released")
-        np_row, side_rows = self._nameplate(app, "np2")
+        np_row, side_rows = self._nameplate(app, np2)
         claims = sorted([(row["side"], row["claimed"]) for row in side_rows])
         self.assertEqual(claims, [("side", 0), ("side2", 1)])
         c.close()
@@ -670,12 +673,12 @@ class WebSocketAPI(_Util, ServerBase, unittest.TestCase):
         c = yield self.make_client()
         yield c.next_non_ack()
         c.send("bind", appid="appid", side="side")
-        c.send("claim", nameplate="np2") # new claim is forbidden
+        c.send("claim", nameplate=np2) # new claim is forbidden
         err = yield c.next_non_ack()
         self.assertEqual(err["type"], "error")
         self.assertEqual(err["error"], "reclaimed")
 
-        np_row, side_rows = self._nameplate(app, "np2")
+        np_row, side_rows = self._nameplate(app, np2)
         claims = sorted([(row["side"], row["claimed"]) for row in side_rows])
         self.assertEqual(claims, [("side", 0), ("side2", 1)])
         c.close()


### PR DESCRIPTION
Update the CLAIM command to assert that the claimed nameplate is all-numeric and not longer than 40 digits. The only other client-to-server command that accepts a nameplate is RELEASE, and that's only used to compare against a previously-CLAIMed one, so we don't need to check its shape there.

The unit tests were violating this rule, so they got updated. New tests were added.

closes #45 
refs magic-wormhole/magic-wormhole-protocols#43
