### PR TITLE
Modernize tox Python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py37,py38,py39,py310,py311,pypy}
+envlist = {py310,py311,py312,py313,py314,pypy}
 skip_missing_interpreters = True
 minversion = 2.4.0
 


### PR DESCRIPTION
Tox config has some very old Pythons and is missing new ones