### PR TITLE
Message ack ("delete") simple

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name="magic-wormhole-mailbox-server",
       ],
       extras_require={
           ':sys_platform=="win32"': ["pywin32"],
-          "dev": ["treq", "tox", "pyflakes"],
+          "dev": ["treq", "tox", "pyflakes", "hypothesis"],
           "release": ["dulwich", "docutils", "wheel"],
       },
       test_suite="wormhole_mailbox_server.test",

--- a/src/wormhole_mailbox_server/server.py
+++ b/src/wormhole_mailbox_server/server.py
@@ -115,6 +115,7 @@ class Mailbox:
                          " VALUES (?,?,?,?,?, ?,?)",
                          (self._app_id, self._mailbox_id, sm.side,
                           sm.phase, sm.body, sm.server_rx, sm.msg_id))
+        # XXX other uses of _touch() seem to use a timestamp, what is server_rx exactly?
         self._touch(sm.server_rx)
         self._db.commit()
 

--- a/src/wormhole_mailbox_server/server.py
+++ b/src/wormhole_mailbox_server/server.py
@@ -127,6 +127,7 @@ class Mailbox:
     def remove_message(self, their_phase, their_side):
         self._db.execute("DELETE FROM `messages`"
                          " WHERE `side`=? AND `phase`=?", (their_side, their_phase))
+        self._db.commit()
 
     def close(self, side, mood, when):
         assert isinstance(side, str), type(side)

--- a/src/wormhole_mailbox_server/server.py
+++ b/src/wormhole_mailbox_server/server.py
@@ -124,6 +124,10 @@ class Mailbox:
         self._add_message(sm)
         self.broadcast_message(sm)
 
+    def remove_message(self, their_phase, their_side):
+        self._db.execute("DELETE FROM `messages`"
+                         " WHERE `side`=? AND `phase`=?", (their_side, their_phase))
+
     def close(self, side, mood, when):
         assert isinstance(side, str), type(side)
         db = self._db

--- a/src/wormhole_mailbox_server/server_websocket.py
+++ b/src/wormhole_mailbox_server/server_websocket.py
@@ -270,9 +270,9 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
         server to this fact via a MESSAGE-ACK. This then allows the server
         to reclaim space by deleting the message.
         """
-        # the server could still send the "deleted" message, right? (I
-        # don't have a message-ordering in mind just intuition) .. if
-        # so we should alert in the above docstring.
+        # the server could still send the "deleted" message later,
+        # right? (I don't have a message-ordering in mind just
+        # intuition) .. if so we should alert in the above docstring.
         if not self._mailbox:
             raise Error("must open mailbox before message-ack'ing")
         for req in ("their-phase", "their-side"):

--- a/src/wormhole_mailbox_server/server_websocket.py
+++ b/src/wormhole_mailbox_server/server_websocket.py
@@ -277,7 +277,7 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
             raise Error("must open mailbox before DELETE-ing")
         for req in ("their-phase", "their-side"):
             if req not in msg:
-                raise Error("delete missing arg '{}'}".format(req))
+                raise Error("delete is missing argument '{}'".format(req))
         # todo: check that "their-side" is different from our side?
         # (warner and meejah discussed this apr 1 but didn't come to a
         # concrete conclusion). options are:

--- a/src/wormhole_mailbox_server/server_websocket.py
+++ b/src/wormhole_mailbox_server/server_websocket.py
@@ -148,8 +148,8 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
                 return self.handle_open(msg, server_rx)
             if mtype == "add":
                 return self.handle_add(msg, server_rx)
-            if mtype == "message-ack":
-                return self.handle_message_ack(msg, server_rx)
+            if mtype == "delete":
+                return self.handle_delete(msg, server_rx)
             if mtype == "close":
                 return self.handle_close(msg, server_rx)
 
@@ -264,20 +264,20 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
                           msg_id=msg_id)
         self._mailbox.add_message(sm)
 
-    def handle_message_ack(self, msg, server_rx):
+    def handle_delete(self, msg, server_rx):
         """
         When a client has (durably) processed a message, it may alert the
-        server to this fact via a MESSAGE-ACK. This then allows the server
+        server to this fact via a DELETE. This then allows the server
         to reclaim space by deleting the message.
         """
         # the server could still send the "deleted" message later,
         # right? (I don't have a message-ordering in mind just
         # intuition) .. if so we should alert in the above docstring.
         if not self._mailbox:
-            raise Error("must open mailbox before message-ack'ing")
+            raise Error("must open mailbox before DELETE-ing")
         for req in ("their-phase", "their-side"):
             if req not in msg:
-                raise Error("message-ack missing '{}'}".format(req))
+                raise Error("delete missing arg '{}'}".format(req))
         # todo: check that "their-side" is different from our side?
         # (warner and meejah discussed this apr 1 but didn't come to a
         # concrete conclusion). options are:

--- a/src/wormhole_mailbox_server/server_websocket.py
+++ b/src/wormhole_mailbox_server/server_websocket.py
@@ -148,6 +148,8 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
                 return self.handle_open(msg, server_rx)
             if mtype == "add":
                 return self.handle_add(msg, server_rx)
+            if mtype == "message-ack":
+                return self.handle_message_ack(msg, server_rx)
             if mtype == "close":
                 return self.handle_close(msg, server_rx)
 
@@ -261,6 +263,33 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
                           body=msg["body"], server_rx=server_rx,
                           msg_id=msg_id)
         self._mailbox.add_message(sm)
+
+    def handle_message_ack(self, msg, server_rx):
+        """
+        When a client has (durably) processed a message, it may alert the
+        server to this fact via a MESSAGE-ACK. This then allows the server
+        to reclaim space by deleting the message.
+        """
+        # the server could still send the "deleted" message, right? (I
+        # don't have a message-ordering in mind just intuition) .. if
+        # so we should alert in the above docstring.
+        if not self._mailbox:
+            raise Error("must open mailbox before message-ack'ing")
+        for req in ("their-phase", "their-side"):
+            if req not in msg:
+                raise Error("message-ack missing '{}'}".format(req))
+        # todo: check that "their-side" is different from our side?
+        # (warner and meejah discussed this apr 1 but didn't come to a
+        # concrete conclusion). options are:
+        # - allow it
+        # - error if you try
+        # - ignore if you try (log it though)
+
+        # this enables the "silent ignore" version of above
+        if msg["their-side"] == self._side:
+            log.msg("Ignoring delete from same-side client for phase '{}'".format(msg["their-phase"]))
+        else:
+            self._mailbox.remove_message(msg["their-phase"], msg["their-side"])
 
     def handle_close(self, msg, server_rx):
         if self._did_close:

--- a/src/wormhole_mailbox_server/test/test_server.py
+++ b/src/wormhole_mailbox_server/test/test_server.py
@@ -6,9 +6,10 @@ from ..server import (make_server, Usage,
                       SidedMessage, CrowdedError, AppNamespace)
 from ..database import create_channel_db, create_usage_db
 
-from hypothesis import given, assume, settings
+from hypothesis import given, settings
 from hypothesis import strategies as st
-from hypothesis.stateful import run_state_machine_as_test
+from hypothesis.stateful import (Bundle, RuleBasedStateMachine, rule, initialize,
+                                 run_state_machine_as_test)
 
 npid = "1"
 
@@ -339,14 +340,6 @@ class Delete(_Util, ServerBase, unittest.TestCase):
         finally:
             m.close(side0, "moody", 987)
             #app.free_mailbox(mbox)
-
-
-import hypothesis.strategies as st
-from hypothesis.database import DirectoryBasedExampleDatabase
-from hypothesis.stateful import Bundle, RuleBasedStateMachine, rule, initialize
-import tempfile
-from collections import defaultdict
-import shutil
 
 
 class MailboxDeletes(RuleBasedStateMachine):

--- a/src/wormhole_mailbox_server/test/test_server.py
+++ b/src/wormhole_mailbox_server/test/test_server.py
@@ -291,8 +291,7 @@ class Delete(_Util, ServerBase, unittest.TestCase):
     When clients send `delete` the server may delete those messages.
 
     - clients should only delete _other_ clients' messages
-    - (is / should it be an error if they try to delete their own?)
-    - can we use Hypothesis in this test-suite?
+      - (currently this is silently ignored .. should be error?)
     """
 
     def test_one_message(self):
@@ -337,7 +336,7 @@ class Delete(_Util, ServerBase, unittest.TestCase):
             for phase in phases:
                 m.remove_message(phase, side0)
             assert m.get_messages() == [], "all messages should be deleted"
-            
+
         finally:
             m.close(side0, "moody", 987)
 

--- a/src/wormhole_mailbox_server/test/test_server.py
+++ b/src/wormhole_mailbox_server/test/test_server.py
@@ -367,13 +367,25 @@ class MailboxDeletes(RuleBasedStateMachine):
 
     @initialize()
     def init_messages(self):
-        print("INIT")
+        ##print("INIT")
+        # need to clear database, so Hypothesis can't find "old" test
+        # stuff?
+
+        # hack: we want a "fresh everything" on each exploration of
+        # the mailbox space .. perhaps should just call .setUp() from
+        # ServerBase again? Better yet: factor out the "create a test
+        # server" to a function and call that here.
+        self.server._apps = {}
+        self.server._db = create_channel_db(":memory:")
         self.have_phases = []
-        # todo: can we "hypothesis" the setup too, to get different
+        # todo: should we "hypothesis" the setup too, to get different
         # values for these?
         self.app = self.server.get_app("appid")
         # wtf? we're calling close() .. not getting exceptions .. but no free_mailbox?
         self.mbox = self.app.open_mailbox("mbox", "side1", 0)
+        ##print("INNIT", self.mbox, self.mbox.get_messages())
+        # double-checking our assumptions
+        assert self.mbox.get_messages() == [], "should be empty on init"
 
     @rule(
         target=messages,
@@ -387,7 +399,7 @@ class MailboxDeletes(RuleBasedStateMachine):
 
     @rule(msg=messages)
     def received(self, msg):
-        print("ADD {}".format(repr(msg.phase)))
+        ##print("ADD {}".format(repr(msg.phase)))
         self.have_phases.append(msg.phase)
         self.mbox.add_message(msg)
 
@@ -397,7 +409,7 @@ class MailboxDeletes(RuleBasedStateMachine):
         phase=st.text(min_size=1),
     )
     def delete(self, phase):
-        print("REMOVE {}".format(repr(phase)))
+        ##print("REMOVE {}".format(repr(phase)))
         try:
             self.have_phases.remove(phase)
         except ValueError:
@@ -407,7 +419,7 @@ class MailboxDeletes(RuleBasedStateMachine):
 
     @rule(msg=messages)
     def retained_agree(self, msg):
-        print("agree?")
+        ##print("agree?", end='')
         mbox_phases = [
             m.phase
             for m in self.mbox.get_messages()
@@ -417,35 +429,37 @@ class MailboxDeletes(RuleBasedStateMachine):
         if msg.phase in self.have_phases:
             if msg.phase not in mbox_phases:
                 print("message should exist")
-            ##assert msg.phase in mbox_phases, "message should exist"
+            assert msg.phase in mbox_phases, "message should exist"
         else:
             if msg.phase in mbox_phases:
                 print("message should not exist")
                 print(repr(msg.phase))
                 for p in mbox_phases:
                     print("  ", repr(p))
-            ##assert msg.phase not in mbox_phases, "message should not exist"
+            assert msg.phase not in mbox_phases, "message should not exist"
 
     def teardown(self):
-        print("teardown", self.mbox)
+        ##print("teardown", self.mbox)
         if self.mbox is not None:
-            try:
-                self.mbox.close(self.side, "happy", 1234)
-            except Exception as e:
-                print("ASDFASDF", e)
+            self.mbox.close(self.side, "happy", 1234)
             self.mbox._shutdown();
             del self.mbox
-        else:
-            print("DINNY HAVE UN")
         self.app.free_mailbox("mbox")
 
 
 class TestDelete(_Util, ServerBase, unittest.TestCase):
+    """
+    A container that looks like the other tests to hold a Hypothesis
+    state-based testing instance.
+
+    (Hypothesis can mimic the normal stdlib TestCase but we're using
+    Twisted's immitation of that here...)
+    """
 
     def create(self):
         return MailboxDeletes(self._server)
 
-    def test_foo(self):
+    def test_state_based_mailbox_messages(self):
         run_state_machine_as_test(self.create)
 
     

--- a/src/wormhole_mailbox_server/test/test_server.py
+++ b/src/wormhole_mailbox_server/test/test_server.py
@@ -287,7 +287,7 @@ class Server(_Util, ServerBase, unittest.TestCase):
 
 class Delete(_Util, ServerBase, unittest.TestCase):
     """
-    When clients send `message-ack` the server may delete those messages.
+    When clients send `delete` the server may delete those messages.
 
     - clients should only delete _other_ clients' messages
     - (is / should it be an error if they try to delete their own?)

--- a/src/wormhole_mailbox_server/test/test_server.py
+++ b/src/wormhole_mailbox_server/test/test_server.py
@@ -6,6 +6,10 @@ from ..server import (make_server, Usage,
                       SidedMessage, CrowdedError, AppNamespace)
 from ..database import create_channel_db, create_usage_db
 
+from hypothesis import given, assume, settings
+from hypothesis import strategies as st
+from hypothesis.stateful import run_state_machine_as_test
+
 npid = "1"
 
 class Server(_Util, ServerBase, unittest.TestCase):
@@ -281,6 +285,170 @@ class Server(_Util, ServerBase, unittest.TestCase):
         m.close("side1", "mood", 1)
 
 
+class Delete(_Util, ServerBase, unittest.TestCase):
+    """
+    When clients send `message-ack` the server may delete those messages.
+
+    - clients should only delete _other_ clients' messages
+    - (is / should it be an error if they try to delete their own?)
+    - can we use Hypothesis in this test-suite?
+    """
+
+    def test_one_message(self):
+        """
+        add and successfully delete one message
+        """
+        app = self._server.get_app("appid")
+        name = app.allocate_nameplate("side1", 42)
+        mbox = app.claim_nameplate(name, "side1", 0)
+        m = app.open_mailbox(mbox, "side1", 0)
+        sm = SidedMessage("side1", "pake", "body", 42, "msgid")
+        m.add_message(sm)
+        assert len(m.get_messages()) == 1, "expected single message"
+
+        m.remove_message("pake", "side1")
+        assert m.get_messages() == [], "expected no messages"
+
+    @settings(
+        # max_examples=10
+    )
+    @given(
+        st.text(min_size=1),
+        st.text(min_size=1),
+        st.text(),
+        st.lists(st.text()),
+        st.text(),
+    )
+    def test_messages(self, side0, mbox, msg_id, phases, body):
+        app = self._server.get_app("appid")
+        m = app.open_mailbox(mbox, side0, 0)
+        try:
+            # would be good to "interleave" some message_ack()s
+            # randomly during add_message() .. nice Hypothesis way to
+            # do that?
+            for phase in phases:
+                sm = SidedMessage(side0, phase, body, 42, msg_id)
+                m.add_message(sm)
+            assert len(m.get_messages()) == len(phases), "mismatched message counts"
+
+            # ack all these messages
+            for phase in phases:
+                m.remove_message(phase, side0)
+            assert m.get_messages() == [], "all messages should be deleted"
+            
+        finally:
+            m.close(side0, "moody", 987)
+            #app.free_mailbox(mbox)
+
+
+import hypothesis.strategies as st
+from hypothesis.database import DirectoryBasedExampleDatabase
+from hypothesis.stateful import Bundle, RuleBasedStateMachine, rule, initialize
+import tempfile
+from collections import defaultdict
+import shutil
+
+
+class MailboxDeletes(RuleBasedStateMachine):
+    """
+    Checks behavior of just the Mailbox under different orderings of message-arrivals and message deletes.
+
+    Invariant: if a message arrived, _and_ a delete arrived, that
+    message should no longer be in the Mailbox
+    """
+
+    def __init__(self, server):
+        super().__init__()
+        self.side = "side"
+        self.server = server
+        self.mbox = None
+
+    messages = Bundle("messages")
+
+    @initialize()
+    def init_messages(self):
+        print("INIT")
+        self.have_phases = []
+        # todo: can we "hypothesis" the setup too, to get different
+        # values for these?
+        self.app = self.server.get_app("appid")
+        # wtf? we're calling close() .. not getting exceptions .. but no free_mailbox?
+        self.mbox = self.app.open_mailbox("mbox", "side1", 0)
+
+    @rule(
+        target=messages,
+        phase=st.text(min_size=1),
+        body=st.text(),
+        msgid=st.text(min_size=1),
+        when=st.integers(1, 2**32),
+    )
+    def add_message(self, phase, body, msgid, when):
+        return SidedMessage(self.side, phase, body, when, msgid)
+
+    @rule(msg=messages)
+    def received(self, msg):
+        print("ADD {}".format(repr(msg.phase)))
+        self.have_phases.append(msg.phase)
+        self.mbox.add_message(msg)
+
+    # can we "guide" this somehow, to hint that it'll get better
+    # results if "phase" actually exists as a message already?
+    @rule(
+        phase=st.text(min_size=1),
+    )
+    def delete(self, phase):
+        print("REMOVE {}".format(repr(phase)))
+        try:
+            self.have_phases.remove(phase)
+        except ValueError:
+            # client deleted this, but we don't have that message
+            pass
+        self.mbox.remove_message(phase, self.side)
+
+    @rule(msg=messages)
+    def retained_agree(self, msg):
+        print("agree?")
+        mbox_phases = [
+            m.phase
+            for m in self.mbox.get_messages()
+        ]
+        # the Mailbox should match what our internal model says, as
+        # far as having a message or not
+        if msg.phase in self.have_phases:
+            if msg.phase not in mbox_phases:
+                print("message should exist")
+            ##assert msg.phase in mbox_phases, "message should exist"
+        else:
+            if msg.phase in mbox_phases:
+                print("message should not exist")
+                print(repr(msg.phase))
+                for p in mbox_phases:
+                    print("  ", repr(p))
+            ##assert msg.phase not in mbox_phases, "message should not exist"
+
+    def teardown(self):
+        print("teardown", self.mbox)
+        if self.mbox is not None:
+            try:
+                self.mbox.close(self.side, "happy", 1234)
+            except Exception as e:
+                print("ASDFASDF", e)
+            self.mbox._shutdown();
+            del self.mbox
+        else:
+            print("DINNY HAVE UN")
+        self.app.free_mailbox("mbox")
+
+
+class TestDelete(_Util, ServerBase, unittest.TestCase):
+
+    def create(self):
+        return MailboxDeletes(self._server)
+
+    def test_foo(self):
+        run_state_machine_as_test(self.create)
+
+    
 class Prune(unittest.TestCase):
 
     def _get_mailbox_updated(self, app, mbox_id):

--- a/src/wormhole_mailbox_server/test/test_server.py
+++ b/src/wormhole_mailbox_server/test/test_server.py
@@ -308,6 +308,10 @@ class Delete(_Util, ServerBase, unittest.TestCase):
         assert len(m.get_messages()) == 1, "expected single message"
 
         m.remove_message("pake", "side1")
+        # make sure it didn't forget to commit() ..
+        # get_messages() does an .execute() which would correctly
+        # commit any active transaction
+        self._server._db.rollback()
         assert m.get_messages() == [], "expected no messages"
 
     @settings(
@@ -324,9 +328,6 @@ class Delete(_Util, ServerBase, unittest.TestCase):
         app = self._server.get_app("appid")
         m = app.open_mailbox(mbox, side0, 0)
         try:
-            # would be good to "interleave" some message_ack()s
-            # randomly during add_message() .. nice Hypothesis way to
-            # do that?
             for phase in phases:
                 sm = SidedMessage(side0, phase, body, 42, msg_id)
                 m.add_message(sm)
@@ -339,7 +340,6 @@ class Delete(_Util, ServerBase, unittest.TestCase):
             
         finally:
             m.close(side0, "moody", 987)
-            #app.free_mailbox(mbox)
 
 
 class MailboxDeletes(RuleBasedStateMachine):
@@ -359,11 +359,8 @@ class MailboxDeletes(RuleBasedStateMachine):
     messages = Bundle("messages")
 
     @initialize()
-    def init_messages(self):
-        ##print("INIT")
-        # need to clear database, so Hypothesis can't find "old" test
-        # stuff?
-
+    def connect(self):
+        ##print()
         # hack: we want a "fresh everything" on each exploration of
         # the mailbox space .. perhaps should just call .setUp() from
         # ServerBase again? Better yet: factor out the "create a test
@@ -374,9 +371,7 @@ class MailboxDeletes(RuleBasedStateMachine):
         # todo: should we "hypothesis" the setup too, to get different
         # values for these?
         self.app = self.server.get_app("appid")
-        # wtf? we're calling close() .. not getting exceptions .. but no free_mailbox?
         self.mbox = self.app.open_mailbox("mbox", "side1", 0)
-        ##print("INNIT", self.mbox, self.mbox.get_messages())
         # double-checking our assumptions
         assert self.mbox.get_messages() == [], "should be empty on init"
 
@@ -409,10 +404,15 @@ class MailboxDeletes(RuleBasedStateMachine):
             # client deleted this, but we don't have that message
             pass
         self.mbox.remove_message(phase, self.side)
+        self.server._db.rollback()
 
-    @rule(msg=messages)
-    def retained_agree(self, msg):
-        ##print("agree?", end='')
+    @rule(msg=messages, rollback=st.sampled_from([True, False]))
+    def retained_agree(self, msg, rollback):
+        if rollback:
+            # if an operation forgot to do .commit() on the database,
+            # this will catch them by removing that transaction
+            self.server._db.rollback()
+
         mbox_phases = [
             m.phase
             for m in self.mbox.get_messages()
@@ -440,7 +440,7 @@ class MailboxDeletes(RuleBasedStateMachine):
         self.app.free_mailbox("mbox")
 
 
-class TestDelete(_Util, ServerBase, unittest.TestCase):
+class TestMailboxDeletes(_Util, ServerBase, unittest.TestCase):
     """
     A container that looks like the other tests to hold a Hypothesis
     state-based testing instance.
@@ -453,9 +453,15 @@ class TestDelete(_Util, ServerBase, unittest.TestCase):
         return MailboxDeletes(self._server)
 
     def test_state_based_mailbox_messages(self):
-        run_state_machine_as_test(self.create)
+        run_state_machine_as_test(
+            self.create,
+            settings=settings(
+                max_examples=200,
+                stateful_step_count=13,
+            )
+        )
 
-    
+
 class Prune(unittest.TestCase):
 
     def _get_mailbox_updated(self, app, mbox_id):


### PR DESCRIPTION
An attempt at the "simple" version of message deletion ("message-ack" or as we've decided "delete") that simply deletes a phase+side message when the client says so.
See https://github.com/magic-wormhole/magic-wormhole-protocols/issues/45

- [ ] how much of the error-space does the Hypothesis test explore?
- [ ] refactor setup / teardown of server/mailboxes/apps in above test
- [ ] reject "self-deletes"? (i.e. if a peer with side X tries to delete "phase+X" what happens?)

