### PR TITLE
make --usage-db= optional

### DIFF
--- a/src/wormhole_mailbox_server/server_tap.py
+++ b/src/wormhole_mailbox_server/server_tap.py
@@ -74,10 +74,11 @@ def makeService(config, channel_db="relay.sqlite", reactor=reactor):
     parent = MultiService()
 
     channel_db = create_or_upgrade_channel_db(config["channel-db"])
-    usage_db = create_or_upgrade_usage_db(config["usage-db"])
-    log_file = (os.fdopen(int(config["log-fd"]), "w")
-                if config["log-fd"] is not None
-                else None)
+    usage_dbfile = config["usage-db"]
+    usage_db = create_or_upgrade_usage_db(usage_dbfile) if usage_dbfile else None
+    log_filename = config["log-fd"]
+    log_file = os.fdopen(int(config["log-fd"]), "w") if log_filename else None
+
     server = make_server(channel_db,
                          allow_list=config["allow-list"],
                          advertise_version=config["advertise-version"],

--- a/src/wormhole_mailbox_server/test/test_service.py
+++ b/src/wormhole_mailbox_server/test/test_service.py
@@ -17,13 +17,13 @@ class Service(unittest.TestCase):
                     with mock.patch("wormhole_mailbox_server.server_tap.make_web_server", return_value=ws) as mws:
                         s = server_tap.makeService(o)
         self.assertEqual(ccdb.mock_calls, [mock.call("relay.sqlite")])
-        self.assertEqual(ccub.mock_calls, [mock.call(None)])
+        self.assertEqual(ccub.mock_calls, [])
         self.assertEqual(ms.mock_calls, [mock.call(cdb, allow_list=True,
                                                    advertise_version=None,
                                                    signal_error=None,
                                                    welcome_motd=None,
                                                    blur_usage=None,
-                                                   usage_db=udb,
+                                                   usage_db=None,
                                                    log_file=None)])
         self.assertEqual(mws.mock_calls, [mock.call(r, True, [])])
         self.assertIsInstance(s, MultiService)
@@ -50,5 +50,30 @@ class Service(unittest.TestCase):
                                                    signal_error=None,
                                                    welcome_motd=None,
                                                    blur_usage=None,
-                                                   usage_db=udb,
+                                                   usage_db=None,
                                                    log_file=fd)])
+
+    def test_usagedb(self):
+        o = server_tap.Options()
+        o.parseOptions(["--usage-db=usage.sqlite"])
+        cdb = object()
+        udb = object()
+        r = mock.Mock()
+        ws = object()
+        with mock.patch("wormhole_mailbox_server.server_tap.create_or_upgrade_channel_db", return_value=cdb) as ccdb:
+            with mock.patch("wormhole_mailbox_server.server_tap.create_or_upgrade_usage_db", return_value=udb) as ccub:
+                with mock.patch("wormhole_mailbox_server.server_tap.make_server", return_value=r) as ms:
+                    with mock.patch("wormhole_mailbox_server.server_tap.make_web_server", return_value=ws) as mws:
+                        s = server_tap.makeService(o)
+        self.assertEqual(ccdb.mock_calls, [mock.call("relay.sqlite")])
+        self.assertEqual(ccub.mock_calls, [mock.call("usage.sqlite")])
+        self.assertEqual(ms.mock_calls, [mock.call(cdb, allow_list=True,
+                                                   advertise_version=None,
+                                                   signal_error=None,
+                                                   welcome_motd=None,
+                                                   blur_usage=None,
+                                                   usage_db=udb,
+                                                   log_file=None)])
+        self.assertEqual(mws.mock_calls, [mock.call(r, True, [])])
+        self.assertIsInstance(s, MultiService)
+        self.assertEqual(len(r.mock_calls), 1) # setServiceParent


### PR DESCRIPTION
The server's internals work fine without a usage db (it just doesn't record any historical data). But the setup code was unconditionally trying to open one, so omitting `--usage-db=` from the arguments caused an error. This improves the setup code to tolerate that.