### PR TITLE
Remove vestigal --log-fd argument

### DIFF
--- a/src/wormhole_mailbox_server/server.py
+++ b/src/wormhole_mailbox_server/server.py
@@ -560,7 +560,7 @@ class AppNamespace:
 
 class Server(service.MultiService):
     def __init__(self, db, allow_list, welcome,
-                 blur_usage, usage_db=None, log_file=None):
+                 blur_usage, usage_db=None):
         service.MultiService.__init__(self)
         self._db = db
         self._allow_list = allow_list
@@ -568,7 +568,6 @@ class Server(service.MultiService):
         self._blur_usage = blur_usage
         self._log_requests = blur_usage is None
         self._usage_db = usage_db
-        self._log_file = log_file
         self._apps = {}
 
     def get_welcome(self):
@@ -688,7 +687,6 @@ def make_server(db, allow_list=True,
                 signal_error=None,
                 blur_usage=None,
                 usage_db=None,
-                log_file=None,
                 welcome_motd=None,
                 ):
     if blur_usage:
@@ -713,4 +711,4 @@ def make_server(db, allow_list=True,
         welcome["error"] = signal_error
 
     return Server(db, allow_list=allow_list, welcome=welcome,
-                  blur_usage=blur_usage, usage_db=usage_db, log_file=log_file)
+                  blur_usage=blur_usage, usage_db=usage_db)

--- a/src/wormhole_mailbox_server/server_tap.py
+++ b/src/wormhole_mailbox_server/server_tap.py
@@ -1,4 +1,4 @@
-import os, json, time
+import json, time
 from twisted.internet import reactor
 from twisted.python import usage, log
 from twisted.application.service import MultiService
@@ -15,13 +15,12 @@ This service forwards short messages between clients, to perform key exchange
 and connection setup."""
 
 class Options(usage.Options):
-    synopsis = "[--port=] [--log-fd] [--blur-usage=] [--usage-db=]"
+    synopsis = "[--port=] [--blur-usage=] [--usage-db=]"
     longdesc = LONGDESC
 
     optParameters = [
         ("port", "p", r"tcp:4000:interface=\:\:", "endpoint to listen on"),
         ("blur-usage", None, None, "round logged access times to improve privacy"),
-        ("log-fd", None, None, "write JSON usage logs to this file descriptor"),
         ("channel-db", None, "relay.sqlite", "location for the state database"),
         ("usage-db", None, None, "record usage data (SQLite)"),
         ("advertise-version", None, None, "version to recommend to clients"),
@@ -39,9 +38,6 @@ class Options(usage.Options):
 
     def opt_disallow_list(self):
         self["allow-list"] = False
-
-    def opt_log_fd(self, arg):
-        self["log-fd"] = int(arg)
 
     def opt_blur_usage(self, arg):
         # --blur-usage= is in seconds. If the option isn't provided, we'll keep
@@ -76,8 +72,6 @@ def makeService(config, channel_db="relay.sqlite", reactor=reactor):
     channel_db = create_or_upgrade_channel_db(config["channel-db"])
     usage_dbfile = config["usage-db"]
     usage_db = create_or_upgrade_usage_db(usage_dbfile) if usage_dbfile else None
-    log_filename = config["log-fd"]
-    log_file = os.fdopen(int(config["log-fd"]), "w") if log_filename else None
 
     server = make_server(channel_db,
                          allow_list=config["allow-list"],
@@ -85,7 +79,6 @@ def makeService(config, channel_db="relay.sqlite", reactor=reactor):
                          signal_error=config["signal-error"],
                          blur_usage=config["blur-usage"],
                          usage_db=usage_db,
-                         log_file=log_file,
                          welcome_motd=config["motd"],
                          )
     server.setServiceParent(parent)

--- a/src/wormhole_mailbox_server/test/test_config.py
+++ b/src/wormhole_mailbox_server/test/test_config.py
@@ -17,7 +17,6 @@ class Config(unittest.TestCase):
                              "usage-db": None,
                              "blur-usage": None,
                              "motd": None,
-                             "log-fd": None,
                              "websocket-protocol-options": [],
                              })
 
@@ -33,7 +32,6 @@ class Config(unittest.TestCase):
                              "usage-db": None,
                              "blur-usage": None,
                              "motd": None,
-                             "log-fd": None,
                              "websocket-protocol-options": [],
                              })
 
@@ -49,7 +47,6 @@ class Config(unittest.TestCase):
                              "usage-db": None,
                              "blur-usage": 60,
                              "motd": None,
-                             "log-fd": None,
                              "websocket-protocol-options": [],
                              })
 
@@ -65,7 +62,6 @@ class Config(unittest.TestCase):
                              "usage-db": None,
                              "blur-usage": None,
                              "motd": None,
-                             "log-fd": None,
                              "websocket-protocol-options": [],
                              })
 
@@ -81,23 +77,6 @@ class Config(unittest.TestCase):
                              "usage-db": None,
                              "blur-usage": None,
                              "motd": None,
-                             "log-fd": None,
-                             "websocket-protocol-options": [],
-                             })
-
-    def test_log_fd(self):
-        o = server_tap.Options()
-        o.parseOptions(["--log-fd=5"])
-        self.assertEqual(o, {"port": PORT,
-                             "channel-db": "relay.sqlite",
-                             "disallow-list": 0,
-                             "allow-list": True,
-                             "advertise-version": None,
-                             "signal-error": None,
-                             "usage-db": None,
-                             "blur-usage": None,
-                             "motd": None,
-                             "log-fd": 5,
                              "websocket-protocol-options": [],
                              })
 
@@ -113,7 +92,6 @@ class Config(unittest.TestCase):
                              "usage-db": None,
                              "blur-usage": None,
                              "motd": None,
-                             "log-fd": None,
                              "websocket-protocol-options": [],
                              })
 
@@ -128,7 +106,6 @@ class Config(unittest.TestCase):
                              "usage-db": None,
                              "blur-usage": None,
                              "motd": None,
-                             "log-fd": None,
                              "websocket-protocol-options": [],
                              })
 
@@ -144,7 +121,6 @@ class Config(unittest.TestCase):
                              "usage-db": None,
                              "blur-usage": None,
                              "motd": None,
-                             "log-fd": None,
                              "websocket-protocol-options": [],
                              })
 
@@ -160,7 +136,6 @@ class Config(unittest.TestCase):
                              "usage-db": "usage.sqlite",
                              "blur-usage": None,
                              "motd": None,
-                             "log-fd": None,
                              "websocket-protocol-options": [],
                              })
 
@@ -176,7 +151,6 @@ class Config(unittest.TestCase):
                              "usage-db": None,
                              "blur-usage": None,
                              "motd": None,
-                             "log-fd": None,
                              "websocket-protocol-options": [("foo", "bar")],
                              })
 
@@ -194,7 +168,6 @@ class Config(unittest.TestCase):
                              "usage-db": None,
                              "blur-usage": None,
                              "motd": None,
-                             "log-fd": None,
                              "websocket-protocol-options": [("foo", "bar"),
                                                             ("baz", [1, "buz"]),
                                                             ],

--- a/src/wormhole_mailbox_server/test/test_service.py
+++ b/src/wormhole_mailbox_server/test/test_service.py
@@ -24,34 +24,10 @@ class Service(unittest.TestCase):
                                                    welcome_motd=None,
                                                    blur_usage=None,
                                                    usage_db=None,
-                                                   log_file=None)])
+                                                   )])
         self.assertEqual(mws.mock_calls, [mock.call(r, True, [])])
         self.assertIsInstance(s, MultiService)
         self.assertEqual(len(r.mock_calls), 1) # setServiceParent
-
-    def test_log_fd(self):
-        o = server_tap.Options()
-        o.parseOptions(["--log-fd=99"])
-        fd = object()
-        cdb = object()
-        udb = object()
-        r = mock.Mock()
-        ws = object()
-        with mock.patch("wormhole_mailbox_server.server_tap.create_or_upgrade_channel_db", return_value=cdb):
-            with mock.patch("wormhole_mailbox_server.server_tap.create_or_upgrade_usage_db", return_value=udb):
-                with mock.patch("wormhole_mailbox_server.server_tap.make_server", return_value=r) as ms:
-                    with mock.patch("wormhole_mailbox_server.server_tap.make_web_server", return_value=ws):
-                        with mock.patch("wormhole_mailbox_server.server_tap.os.fdopen",
-                                        return_value=fd) as f:
-                            server_tap.makeService(o)
-        self.assertEqual(f.mock_calls, [mock.call(99, "w")])
-        self.assertEqual(ms.mock_calls, [mock.call(cdb, allow_list=True,
-                                                   advertise_version=None,
-                                                   signal_error=None,
-                                                   welcome_motd=None,
-                                                   blur_usage=None,
-                                                   usage_db=None,
-                                                   log_file=fd)])
 
     def test_usagedb(self):
         o = server_tap.Options()
@@ -73,7 +49,7 @@ class Service(unittest.TestCase):
                                                    welcome_motd=None,
                                                    blur_usage=None,
                                                    usage_db=udb,
-                                                   log_file=None)])
+                                                   )])
         self.assertEqual(mws.mock_calls, [mock.call(r, True, [])])
         self.assertIsInstance(s, MultiService)
         self.assertEqual(len(r.mock_calls), 1) # setServiceParent

--- a/src/wormhole_mailbox_server/test/test_stats.py
+++ b/src/wormhole_mailbox_server/test/test_stats.py
@@ -261,32 +261,3 @@ class Mailbox(_Make, unittest.TestCase):
         self.assertEqual(db.execute("SELECT * FROM `mailboxes`").fetchall(),
                          [dict(app_id="appid", for_nameplate=1, result="crowded",
                                started=1, waiting_time=3, total_time=7)])
-
-## class LogToStdout(unittest.TestCase):
-##     def test_log(self):
-##         # emit lines of JSON to log_file, if set
-##         log_file = io.StringIO()
-##         t = Transit(blur_usage=None, log_file=log_file, usage_db=None)
-##         t.recordUsage(started=123, result="happy", total_bytes=100,
-##                       total_time=10, waiting_time=2)
-##         self.assertEqual(json.loads(log_file.getvalue()),
-##                          {"started": 123, "total_time": 10,
-##                           "waiting_time": 2, "total_bytes": 100,
-##                           "mood": "happy"})
-
-##     def test_log_blurred(self):
-##         # if blurring is enabled, timestamps should be rounded to the
-##         # requested amount, and sizes should be rounded up too
-##         log_file = io.StringIO()
-##         t = Transit(blur_usage=60, log_file=log_file, usage_db=None)
-##         t.recordUsage(started=123, result="happy", total_bytes=11999,
-##                       total_time=10, waiting_time=2)
-##         self.assertEqual(json.loads(log_file.getvalue()),
-##                          {"started": 120, "total_time": 10,
-##                           "waiting_time": 2, "total_bytes": 20000,
-##                           "mood": "happy"})
-
-##     def test_do_not_log(self):
-##         t = Transit(blur_usage=60, log_file=None, usage_db=None)
-##         t.recordUsage(started=123, result="happy", total_bytes=11999,
-##                       total_time=10, waiting_time=2)


### PR DESCRIPTION
This was a leftover from when we split the mailbox server out of the client code. The transit relay (which went into a third repository) had a configurable logging mechanism that included a --log-fd=NN argument, which could be used to e.g. write JSON-formatted usage data to an external ingest system over a numbered file descriptor. In the transit relay, that turned into a SQLite-based usage database. In this mailbox server, we started with SQLite and never implemented the file descriptor approach. But the --log-fd= argument, and some internal code, remained.

This deletes the argument and the internal code which was opening, but never using, that file descriptor.