### PR TITLE
add address-id tracker and connections database

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,79 @@
+# Mailbox Server Operations Support
+
+In addition to the nameplates, mailboxes, and messages, which are the core of the Mailbox Server's functionality, the server also tracks information to assist with the operational needs of the service. Overall statistics like connections-per-day and client version distributions help guide development. Some clients are buggy or abusive, and it is helpful to have information on the messages being exchanged to investigate these problems. On the other hand, we want to minimize the amount of information the server is collecting about clients and users.
+
+The goal is to separate, as much as possible, the core functionality of the mailbox server (what clients need), from the data and code that supports operation of the server itself (what the server operators and client developers need). We try to put these different kinds of information into separate database files.
+
+## Side Strings
+
+For each connection, the client submits a `side` string. This is supposed to be a randomly-generated base32 string, long enough to avoid accidental collisions. The `side` is used to track which clients are accessing each nameplate and mailbox. If a client temporarily loses its connection to the mailbox server, it should use the same `side` when it reconnects, otherwise the server will think this is an unrelated client and will signal a "crowded" error.
+
+## Address Identifiers
+
+An "Address Identifier", or "addrid" for short, is a tuple of `(generation, counter)`. Both are positive integers (counting upwards from 1). It is printed as `"addr-%d-%d" % (generation, counter)`.
+
+Within a generation, each unique IP address is assigned the next counter value. The generation is incremented on a periodic basis (about every 24 hours). The `address_ids` table maintains this mapping. Each time the generation is incremented, the `address_ids` table is erased. This table is the only place where IP addresses are recorded. All other logging and operational-support interfaces refer to the addrid instead. This makes it easy to tell when two connections are from the same place, without exposing IP addresses.
+
+This table lives in a separate database. It is enabled by passing `--addrid-db=` when starting the server, pointing at the filename where the DB should be stored. By using `--addrid-db=:memory:`, the database is kept in RAM, reducing the exposure further. The `--generation-duration=` argument specifies (in seconds) the erasure interval, and defaults to 86400 (one day).
+
+## Connection Table
+
+The server maintains a table of active websocket connections. These rows are inserted each time a new connection is established, and deleted when it is lost. The entire table is erased at server startup. This table is kept in the main `--channel-db` database (usually `relay.sqlite`).
+
+The table will show stale information if the server has been stopped (the table is not erased at server shutdown, only startup).
+
+The connection table records:
+* addrid (generation,counter)
+* connection established time
+* last message received time
+* side (if any), as established by the BIND message
+* (implementation,version) tuple, as reported by the client during BIND
+
+## Usage Database
+
+To measure historical activity, the server maintains another separate "usage" database. If enabled (with `--usage-db=`), this records information about each nameplate and mailbox.
+
+The rows are added as the nameplate/mailbox is retired. This happens when the last side releases their claim on it, either explicitly, or because their connection was lost and the claim timed out (which happens after 10 minutes, by default).
+
+The `nameplates` table records:
+
+* `app_id`
+* `started`: timestamp of the nameplate being created
+* `waiting_time`: interval from start to the second side appearing
+* `total_time`: interval from start to retirement
+* `result`: server-side "mood" of the connection: happy/lonely/pruney/crowded
+
+The nameplate `result` indicates what the server thinks about the connection:
+
+* `happy`: two sides used the nameplate and explicitly released it
+* `lonely`: only one side ever used the nameplate
+* `pruney`: the nameplate was retired because the connections timed out
+* `crowded`: three or more sides attempted to use the same nameplate
+
+The `mailboxes` table records:
+
+* `app_id`
+* `for_nameplate`: a boolean, True if the mailbox was allocated for a nameplate
+* `started`: timestamp of the mailbox being created
+* `waiting_time`: interval from start to second side appearing
+* `total_time`: interval from start to retirement
+* `result`: client-reported "mood": happy/scary/lonely/errory/pruney/crowded
+
+The mailbox `result` indicates what the clients thought about the connection. Each client's CLOSE message includes a "mood", and the server records the most severe mood in the record:
+
+* `happy`: two sides used the mailbox successfully
+* `scary`: a client observed cryptographic errors indicative of a failed attack
+* `lonely`: only one side ever used the mailbox, or a client never saw their peer's message
+* `pruney`: the mailbox was retired because the connections timed out
+* `crowded`: three or more sides attempted to open the same mailbox
+
+The usage database also maintains a table of client versions. These are self-reported `(implementation, version)` strings, e.g. `("python", "0.24.0")`. Client developers are encouraged to use a unique string (each `implementation` should have a specific project home page and repository), to facilitate reports of version uptake.
+
+The `client_versions` table gets a new row each time a client connects to the server and issues the BIND command. This does not necessarily mean the client participated in a mailbox connection.
+
+The `side` string is included in the `client_versions` table to help filter out duplicates. The table contains:
+
+* `app_id`
+* `side`
+* `connect_time`: timestamp of the receipt of the BIND command
+* `implementation`, `version`: client-reported version information

--- a/src/wormhole_mailbox_server/address_id.py
+++ b/src/wormhole_mailbox_server/address_id.py
@@ -1,0 +1,64 @@
+
+class AddressIDTracker(object):
+    def __init__(self, channel_db, addrid_db):
+        assert channel_db
+        assert addrid_db
+        self._channel_db = channel_db
+        self._addrid_db = addrid_db
+
+    def check_generation(self, now, duration, force=False):
+        db = self._channel_db
+        row = db.execute("SELECT * FROM `addrid_generation`").fetchone()
+        if force or not row or (row["started"] + duration) < now:
+            next_started = now # first generation starts now
+            if row:
+                next_started = row["started"] + duration # don't accumulate lag
+                if next_started + duration < now:
+                    # but don't let the new generation end early
+                    next_started = now
+            next_generation = row["generation"] + 1 if row else 1
+            db.execute("DELETE FROM `addrid_generation`")
+            db.execute("INSERT INTO `addrid_generation`"
+                             " (`generation`, `started`)"
+                             " VALUES(?,?)",
+                             (next_generation, next_started))
+            db.commit()
+            self._addrid_db.execute("DELETE FROM `address_ids`")
+            self._addrid_db.commit()
+
+    def get_id(self, addr_type, addr): # -> (generation, counter)
+        # we should only record one generation at a time, so there
+        # shouldn't be more than one match
+        row = self._addrid_db.execute("SELECT * FROM `address_ids`"
+                                      " WHERE `type`=? AND `address`=?",
+                                      (addr_type, addr)).fetchone()
+        if row:
+            return (row["generation"], row["counter"])
+        # else allocate and insert
+
+        current = self._channel_db.execute("SELECT * FROM `addrid_generation`").fetchone()
+        assert current
+        generation = current["generation"]
+        top_row = self._addrid_db.execute("SELECT `counter` FROM `address_ids`"
+                                          " WHERE `generation`=?"
+                                          " ORDER BY `counter` DESC"
+                                          " LIMIT 1",
+                                          (generation,)).fetchone()
+        counter = top_row["counter"]+1 if top_row else 1
+        self._addrid_db.execute("INSERT INTO `address_ids`"
+                                " (`generation`, `counter`, `type`, `address`)"
+                                " VALUES(?,?,?,?)",
+                                (generation, counter, addr_type, addr))
+        self._addrid_db.commit()
+        address_id = (generation, counter)
+        return address_id
+
+    def get_address(self, address_id):
+        (generation, counter) = address_id
+        row = self._addrid_db.execute("SELECT * FROM `address_ids`"
+                                      " WHERE `generation`=? AND `counter`=?",
+                                      (generation, counter)).fetchone()
+        if row:
+            return (row["type"], row["address"])
+        else:
+            return None

--- a/src/wormhole_mailbox_server/connections.py
+++ b/src/wormhole_mailbox_server/connections.py
@@ -1,0 +1,58 @@
+
+class ConnectionTable(object):
+    def __init__(self, db):
+        self._db = db
+
+    def clear(self):
+        self._db.execute("DELETE FROM `connection_messages`")
+        self._db.execute("DELETE FROM `connections`")
+        self._db.commit()
+
+    def established(self, address_id, now):
+        if not address_id:
+            address_id = (None, None) # not tracking addresses
+        (addrid_generation, addrid_counter) = address_id
+        id = None
+        if self._db:
+            sql = ("INSERT INTO `connections`"
+                   " (`addrid_generation`, `addrid_counter`, `connected`, `active`)"
+                   " VALUES(?,?,?,?)")
+            id = self._db.execute(sql,
+                                  (addrid_generation, addrid_counter, now, now)
+                                  ).lastrowid
+            self._db.commit()
+        return Connection(self._db, id)
+
+class Connection(object):
+    def __init__(self, connections_db, id):
+        self._db = connections_db
+        self._id = id
+
+    def bound(self, side, client_version):
+        if self._db:
+            (implementation, version) = client_version
+            self._db.execute("UPDATE `connections`"
+                             " SET `side`=?, `implementation`=?, `version`=?"
+                             " WHERE `id`=?",
+                             (side, implementation, version, self._id))
+            self._db.commit()
+
+    def add_message(self, now, name):
+        if self._db:
+            self._db.execute("UPDATE `connections`"
+                             " SET `active`=?"
+                             " WHERE `id`=?",
+                             (now, self._id))
+            self._db.execute("INSERT INTO `connection_messages`"
+                             " (`id`, `when`, `name`)"
+                             " VALUES(?,?,?)",
+                             (self._id, now, name))
+            self._db.commit()
+
+    def lost(self):
+        if self._db:
+            self._db.execute("DELETE FROM `connection_messages` WHERE `id`=?",
+                             (self._id,))
+            self._db.execute("DELETE FROM `connections` WHERE `id`=?",
+                             (self._id,))
+            self._db.commit()

--- a/src/wormhole_mailbox_server/database.py
+++ b/src/wormhole_mailbox_server/database.py
@@ -22,8 +22,9 @@ def get_upgrader(name, new_version):
         raise ValueError("no upgrader for %d" % new_version)
 
 
-CHANNELDB_TARGET_VERSION = 1
+CHANNELDB_TARGET_VERSION = 2
 USAGEDB_TARGET_VERSION = 2
+ADDRIDDB_TARGET_VERSION = 1
 
 def dict_factory(cursor, row):
     d = {}
@@ -131,6 +132,9 @@ def create_or_upgrade_usage_db(dbfile):
         return None
     return _get_db(dbfile, "usage", USAGEDB_TARGET_VERSION)
 
+def create_or_upgrade_addrid_db(dbfile):
+    return _get_db(dbfile, "addrid", ADDRIDDB_TARGET_VERSION)
+
 class DBDoesntExist(Exception):
     pass
 
@@ -167,6 +171,17 @@ def create_usage_db(dbfile):
     else:
         db = _atomic_create_and_initialize_db(dbfile, "usage",
                                               USAGEDB_TARGET_VERSION)
+    return db
+
+def create_addrid_db(dbfile):
+    if dbfile == ":memory:":
+        db = _open_db_connection(dbfile)
+        _initialize_db_schema(db, "addrid", ADDRIDDB_TARGET_VERSION)
+    elif os.path.exists(dbfile):
+        raise DBAlreadyExists()
+    else:
+        db = _atomic_create_and_initialize_db(dbfile, "addrid",
+                                              ADDRIDDB_TARGET_VERSION)
     return db
 
 def dump_db(db):

--- a/src/wormhole_mailbox_server/db-schemas/addrid-v1.sql
+++ b/src/wormhole_mailbox_server/db-schemas/addrid-v1.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `version`
+(
+ `version` INTEGER -- contains one row, set to 1
+);
+
+CREATE TABLE `address_ids`
+(
+  `generation` INTEGER,
+  `counter` INTEGER,
+  `type` VARCHAR, -- "ipv4" or "ipv6"
+  `address` VARCHAR, -- "1.2.3.4" or "1:2::3:4"
+  `retain` INTEGER
+);

--- a/src/wormhole_mailbox_server/db-schemas/channel-v2.sql
+++ b/src/wormhole_mailbox_server/db-schemas/channel-v2.sql
@@ -1,0 +1,95 @@
+
+-- note: anything which isn't an boolean, integer, or human-readable unicode
+-- string, (i.e. binary strings) will be stored as hex
+
+CREATE TABLE `version`
+(
+ `version` INTEGER -- contains one row, set to 2
+);
+
+
+-- Wormhole codes use a "nameplate": a short name which is only used to
+-- reference a specific (long-named) mailbox. The codes only use numeric
+-- nameplates, but the protocol and server allow can use arbitrary strings.
+CREATE TABLE `nameplates`
+(
+ `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+ `app_id` VARCHAR,
+ `name` VARCHAR,
+ `mailbox_id` VARCHAR REFERENCES `mailboxes`(`id`),
+ `request_id` VARCHAR -- from 'allocate' message, for future deduplication
+);
+CREATE INDEX `nameplates_idx` ON `nameplates` (`app_id`, `name`);
+CREATE INDEX `nameplates_mailbox_idx` ON `nameplates` (`app_id`, `mailbox_id`);
+CREATE INDEX `nameplates_request_idx` ON `nameplates` (`app_id`, `request_id`);
+
+CREATE TABLE `nameplate_sides`
+(
+ `nameplates_id` REFERENCES `nameplates`(`id`),
+ `claimed` BOOLEAN, -- True after claim(), False after release()
+ `side` VARCHAR,
+ `added` INTEGER -- time when this side first claimed the nameplate
+);
+
+
+-- Clients exchange messages through a "mailbox", which has a long (randomly
+-- unique) identifier and a queue of messages.
+-- `id` is randomly-generated and unique across all apps.
+CREATE TABLE `mailboxes`
+(
+ `app_id` VARCHAR,
+ `id` VARCHAR PRIMARY KEY,
+ `updated` INTEGER, -- time of last activity, used for pruning
+ `for_nameplate` BOOLEAN -- allocated for a nameplate, not standalone
+);
+CREATE INDEX `mailboxes_idx` ON `mailboxes` (`app_id`, `id`);
+
+CREATE TABLE `mailbox_sides`
+(
+ `mailbox_id` REFERENCES `mailboxes`(`id`),
+ `opened` BOOLEAN, -- True after open(), False after close()
+ `side` VARCHAR,
+ `added` INTEGER, -- time when this side first opened the mailbox
+ `mood` VARCHAR
+);
+
+CREATE TABLE `messages`
+(
+ `app_id` VARCHAR,
+ `mailbox_id` VARCHAR,
+ `side` VARCHAR,
+ `phase` VARCHAR, -- numeric or string
+ `body` VARCHAR,
+ `server_rx` INTEGER,
+ `msg_id` VARCHAR
+);
+CREATE INDEX `messages_idx` ON `messages` (`app_id`, `mailbox_id`);
+
+-- address ID generations: actual addresses are in a separate DB
+
+CREATE TABLE `addrid_generation` -- one row
+(
+ `generation` INTEGER, -- current generation ID, increments from one
+ `started` INTEGER -- time when this generation started
+);
+
+-- current connections
+
+CREATE TABLE `connections`
+(
+ `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+ `addrid_generation` INTEGER,
+ `addrid_counter` INTEGER,
+ `connected` INTEGER, -- seconds since epoch: websocket establishment
+ `side` VARCHAR,
+ `implementation` VARCHAR,
+ `version` VARCHAR,
+ `active` INTEGER -- second since epoch: last command received
+);
+
+CREATE TABLE `connection_messages`
+(
+ `id` REFERENCES `connections`(`id`),
+ `when` INTEGER,
+ `name` VARCHAR
+);

--- a/src/wormhole_mailbox_server/db-schemas/upgrade-channel-to-v2.sql
+++ b/src/wormhole_mailbox_server/db-schemas/upgrade-channel-to-v2.sql
@@ -1,0 +1,28 @@
+CREATE TABLE `addrid_generation` -- one row
+(
+ `generation` INTEGER, -- current generation ID, increments from one
+ `started` INTEGER, -- time when this generation started
+ `ends` INTEGER -- scheduled end of this generation
+);
+
+CREATE TABLE `connections`
+(
+ `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+ `addrid_generation` INTEGER,
+ `addrid_counter` INTEGER,
+ `connected` INTEGER, -- seconds since epoch: websocket establishment
+ `side` VARCHAR,
+ `implementation` VARCHAR,
+ `version` VARCHAR,
+ `active` INTEGER -- second since epoch: last command received
+);
+
+CREATE TABLE `connection_messages`
+(
+ `id` REFERENCES `connections`(`id`),
+ `when` INTEGER,
+ `name` VARCHAR
+);
+
+DELETE FROM `version`;
+INSERT INTO `version` (`version`) VALUES (2);

--- a/src/wormhole_mailbox_server/server.py
+++ b/src/wormhole_mailbox_server/server.py
@@ -2,6 +2,8 @@ import os, random, base64, re
 from collections import namedtuple
 from twisted.python import log
 from twisted.application import service
+from .address_id import AddressIDTracker
+from .connections import ConnectionTable
 
 def generate_mailbox_id():
     return base64.b32encode(os.urandom(8)).lower().strip(b"=").decode("ascii")
@@ -560,7 +562,7 @@ class AppNamespace:
 
 class Server(service.MultiService):
     def __init__(self, db, allow_list, welcome,
-                 blur_usage, usage_db=None):
+                 blur_usage, usage_db=None, addrid_db=None):
         service.MultiService.__init__(self)
         self._db = db
         self._allow_list = allow_list
@@ -568,12 +570,23 @@ class Server(service.MultiService):
         self._blur_usage = blur_usage
         self._log_requests = blur_usage is None
         self._usage_db = usage_db
+
+        self._addrid_tracker = AddressIDTracker(self._db, addrid_db) if addrid_db else None
+        self._connection_table = ConnectionTable(self._db)
         self._apps = {}
 
     def get_welcome(self):
         return self._welcome
     def get_log_requests(self):
         return self._log_requests
+    def get_address_id(self, peer_type, peer_host):
+        if self._addrid_tracker:
+            return self._addrid_tracker.get_id(peer_type, peer_host)
+        return None
+
+    def connection_established(self, address_id, now):
+        c = self._connection_table.established(address_id, now)
+        return c
 
     def get_app(self, app_id):
         assert isinstance(app_id, str)
@@ -613,6 +626,14 @@ class Server(service.MultiService):
             if not in_use:
                 del self._apps[app_id]
         log.msg(f"app prune ends, {len(self._apps)} apps")
+
+
+    def check_addrid_generation(self, now, generation_duration, force=False):
+        if self._addrid_tracker:
+            self._addrid_tracker.check_generation(now, generation_duration, force)
+
+    def clear_connections(self):
+        self._connection_table.clear()
 
     def dump_stats(self, now, rebooted):
         if not self._usage_db:
@@ -688,6 +709,7 @@ def make_server(db, allow_list=True,
                 blur_usage=None,
                 usage_db=None,
                 welcome_motd=None,
+                addrid_db=None,
                 ):
     if blur_usage:
         log.msg("blurring access times to %d seconds" % blur_usage)
@@ -711,4 +733,4 @@ def make_server(db, allow_list=True,
         welcome["error"] = signal_error
 
     return Server(db, allow_list=allow_list, welcome=welcome,
-                  blur_usage=blur_usage, usage_db=usage_db)
+                  blur_usage=blur_usage, usage_db=usage_db, addrid_db=addrid_db)

--- a/src/wormhole_mailbox_server/server_tap.py
+++ b/src/wormhole_mailbox_server/server_tap.py
@@ -8,7 +8,8 @@ from twisted.internet import endpoints
 from .increase_rlimits import increase_rlimits
 from .server import make_server
 from .web import make_web_server
-from .database import create_or_upgrade_channel_db, create_or_upgrade_usage_db
+from .database import (create_or_upgrade_channel_db, create_or_upgrade_usage_db,
+                       create_or_upgrade_addrid_db)
 
 LONGDESC = """This plugin sets up a 'Mailbox' server for magic-wormhole.
 This service forwards short messages between clients, to perform key exchange
@@ -23,6 +24,8 @@ class Options(usage.Options):
         ("blur-usage", None, None, "round logged access times to improve privacy"),
         ("channel-db", None, "relay.sqlite", "location for the state database"),
         ("usage-db", None, None, "record usage data (SQLite)"),
+        ("addrid-db", None, None, "IP address mapping data (SQLite)"),
+        ("generation-duration", None, 86400, "lifetime of IP-address tracking table"),
         ("advertise-version", None, None, "version to recommend to clients"),
         ("signal-error", None, None, "force all clients to fail with a message"),
         ("motd", None, None, "Send a Message of the Day in the welcome"),
@@ -72,6 +75,9 @@ def makeService(config, channel_db="relay.sqlite", reactor=reactor):
     channel_db = create_or_upgrade_channel_db(config["channel-db"])
     usage_dbfile = config["usage-db"]
     usage_db = create_or_upgrade_usage_db(usage_dbfile) if usage_dbfile else None
+    addrid_dbfile = config["addrid-db"]
+    addrid_db = create_or_upgrade_addrid_db(addrid_dbfile) if addrid_dbfile else None
+    generation_duration = config["generation-duration"]
 
     server = make_server(channel_db,
                          allow_list=config["allow-list"],
@@ -80,8 +86,17 @@ def makeService(config, channel_db="relay.sqlite", reactor=reactor):
                          blur_usage=config["blur-usage"],
                          usage_db=usage_db,
                          welcome_motd=config["motd"],
+                         addrid_db=addrid_db,
                          )
     server.setServiceParent(parent)
+
+    # initialize first generation of the address-id tracking table,
+    # ignored if the server didn't build a tracker.
+    server.check_addrid_generation(time.time(), generation_duration, force=True)
+
+    # clear stale connection records from previous run
+    server.clear_connections()
+
     rebooted = time.time()
     def expire():
         now = time.time()
@@ -92,6 +107,11 @@ def makeService(config, channel_db="relay.sqlite", reactor=reactor):
             # catch-and-log exceptions during prune, so a single error won't
             # kill the loop. See #13 for details.
             log.msg("error during prune_all_apps")
+            log.err(e)
+        try:
+            server.check_addrid_generation(now, generation_duration)
+        except Exception as e:
+            log.msg("error during check_addrid_generation")
             log.err(e)
         server.dump_stats(now, rebooted=rebooted)
     TimerService(EXPIRATION_CHECK_PERIOD, expire).setServiceParent(parent)

--- a/src/wormhole_mailbox_server/server_websocket.py
+++ b/src/wormhole_mailbox_server/server_websocket.py
@@ -4,7 +4,7 @@ from twisted.python import log
 from twisted.logger import Logger
 from autobahn.twisted import websocket
 from .server import CrowdedError, ReclaimedError, SidedMessage, check_valid_nameplate
-from .util import dict_to_bytes, bytes_to_dict
+from .util import dict_to_bytes, bytes_to_dict, str_or_none
 
 # The WebSocket allows the client to send "commands" to the server, and the
 # server to send "responses" to the client. Note that commands and responses
@@ -156,6 +156,11 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
             else:
                 peer_type = "ipv4"
         self._peer_addr_port = (peer_type, peer_host, int(peer_port))
+        # address_id is None if the address tracker is disabled (no --addrid-db=)
+        address_id = self.factory._server.get_address_id(peer_type, peer_host)
+        self._addr_id = address_id # for logging
+        now = time.time()
+        self._connection_tracker = self.factory._server.connection_established(address_id, now)
 
         if rv.get_log_requests():
             v = 4 if peer_type == "ipv4" else 6
@@ -201,6 +206,8 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
             self.send("ack", id=msg.get("id"))
 
             mtype = msg["type"]
+            self._connection_tracker.add_message(server_rx, mtype)
+
             if mtype == "ping":
                 return self.handle_ping(msg)
             if mtype == "bind":
@@ -243,8 +250,11 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
         self._app = self.factory._server.get_app(msg["appid"])
         self._side = msg["side"]
         client_version = msg.get("client_version", (None, None))
+        # ignore extra args or non-string/None
+        client_version = (str_or_none(client_version[0]), str_or_none(client_version[1]))
         # e.g. ("python", "0.xyz") . <=0.10.5 did not send client_version
         self._app.log_client_version(server_rx, self._side, client_version)
+        self._connection_tracker.bound(self._side, client_version)
 
 
     def handle_list(self):
@@ -369,6 +379,7 @@ class WebSocketServer(websocket.WebSocketServerProtocol):
 
     def onClose(self, wasClean, code, reason):
         #log.msg("onClose", self, self._mailbox, self._listening)
+        self._connection_tracker.lost()
         if self._mailbox and self._listening:
             self._mailbox.remove_listener(self)
 

--- a/src/wormhole_mailbox_server/test/test_addrid.py
+++ b/src/wormhole_mailbox_server/test/test_addrid.py
@@ -1,0 +1,96 @@
+from twisted.trial import unittest
+from ..database import create_channel_db, create_addrid_db
+from ..address_id import AddressIDTracker
+
+class AddressID(unittest.TestCase):
+    def test_generations(self):
+        db = create_channel_db(":memory:")
+        addr_db = create_addrid_db(":memory:")
+        tracker = AddressIDTracker(db, addr_db)
+        duration = 100
+
+        now = 1
+        tracker.check_generation(now, duration, force=True)
+        row = db.execute("SELECT * FROM addrid_generation").fetchone()
+        self.assertEqual(row["generation"], 1)
+        self.assertEqual(row["started"], 1)
+        rows = addr_db.execute("SELECT * FROM address_ids").fetchall()
+        self.assertEqual(rows, [])
+
+        # generation is still going
+        now = 10
+        tracker.check_generation(now, duration)
+        row = db.execute("SELECT * FROM addrid_generation").fetchone()
+        self.assertEqual(row["generation"], 1)
+        self.assertEqual(row["started"], 1)
+
+        # generation just finished, new one starts
+        now = 102
+        tracker.check_generation(now, duration)
+        row = db.execute("SELECT * FROM addrid_generation").fetchone()
+        self.assertEqual(row["generation"], 2)
+        self.assertEqual(row["started"], 101)
+
+        # don't accumulate lag
+        now = 222
+        tracker.check_generation(now, duration)
+        row = db.execute("SELECT * FROM addrid_generation").fetchone()
+        self.assertEqual(row["generation"], 3)
+        self.assertEqual(row["started"], 201)
+
+        # but if we're so late that the new generation would end early, reset and start from now
+        now = 500
+        tracker.check_generation(now, duration)
+        row = db.execute("SELECT * FROM addrid_generation").fetchone()
+        self.assertEqual(row["generation"], 4)
+        self.assertEqual(row["started"], 500)
+
+        # check the edge
+        now = 600
+        tracker.check_generation(now, duration)
+        row = db.execute("SELECT * FROM addrid_generation").fetchone()
+        self.assertEqual(row["generation"], 4)
+        self.assertEqual(row["started"], 500)
+
+        now = 601
+        tracker.check_generation(now, duration)
+        row = db.execute("SELECT * FROM addrid_generation").fetchone()
+        self.assertEqual(row["generation"], 5)
+        self.assertEqual(row["started"], 600)
+
+    def test_address_ids(self):
+        db = create_channel_db(":memory:")
+        addr_db = create_addrid_db(":memory:")
+        tracker = AddressIDTracker(db, addr_db)
+        duration = 100
+
+        now = 1
+        tracker.check_generation(now, duration, force=True)
+
+        id1 = tracker.get_id("ipv4", "1.2.3.4")
+        self.assertEqual(id1, (1,1))
+        id1a = tracker.get_id("ipv4", "1.2.3.4")
+        self.assertEqual(id1a, id1)
+        id2 = tracker.get_id("ipv4", "2.3.4.5")
+        self.assertEqual(id2, (1,2))
+        id3 = tracker.get_id("ipv6", "2::3")
+        self.assertEqual(id3, (1,3))
+
+        self.assertEqual(tracker.get_address((1,1)), ("ipv4", "1.2.3.4"))
+        self.assertEqual(tracker.get_address((1,2)), ("ipv4", "2.3.4.5"))
+        self.assertEqual(tracker.get_address((1,3)), ("ipv6", "2::3"))
+
+        now = 105
+        tracker.check_generation(now, duration)
+        self.assertEqual(tracker.get_address((1,1)), None)
+        self.assertEqual(tracker.get_address((1,2)), None)
+        self.assertEqual(tracker.get_address((1,3)), None)
+
+        idnext1 = tracker.get_id("ipv4", "1.2.3.4")
+        self.assertEqual(idnext1, (2,1))
+        idnext1a = tracker.get_id("ipv4", "1.2.3.4")
+        self.assertEqual(idnext1a, idnext1)
+        idnext2 = tracker.get_id("ipv4", "2.3.4.5")
+        self.assertEqual(idnext2, (2,2))
+        idnext3 = tracker.get_id("ipv6", "2::3")
+        self.assertEqual(idnext3, (2,3))

--- a/src/wormhole_mailbox_server/test/test_config.py
+++ b/src/wormhole_mailbox_server/test/test_config.py
@@ -18,6 +18,8 @@ class Config(unittest.TestCase):
                              "blur-usage": None,
                              "motd": None,
                              "websocket-protocol-options": [],
+                             "addrid-db": None,
+                             "generation-duration": 86400,
                              })
 
     def test_advertise_version(self):
@@ -33,6 +35,8 @@ class Config(unittest.TestCase):
                              "blur-usage": None,
                              "motd": None,
                              "websocket-protocol-options": [],
+                             "addrid-db": None,
+                             "generation-duration": 86400,
                              })
 
     def test_blur(self):
@@ -48,6 +52,8 @@ class Config(unittest.TestCase):
                              "blur-usage": 60,
                              "motd": None,
                              "websocket-protocol-options": [],
+                             "addrid-db": None,
+                             "generation-duration": 86400,
                              })
 
     def test_channel_db(self):
@@ -63,6 +69,8 @@ class Config(unittest.TestCase):
                              "blur-usage": None,
                              "motd": None,
                              "websocket-protocol-options": [],
+                             "addrid-db": None,
+                             "generation-duration": 86400,
                              })
 
     def test_disallow_list(self):
@@ -78,6 +86,8 @@ class Config(unittest.TestCase):
                              "blur-usage": None,
                              "motd": None,
                              "websocket-protocol-options": [],
+                             "addrid-db": None,
+                             "generation-duration": 86400,
                              })
 
     def test_port(self):
@@ -93,6 +103,8 @@ class Config(unittest.TestCase):
                              "blur-usage": None,
                              "motd": None,
                              "websocket-protocol-options": [],
+                             "addrid-db": None,
+                             "generation-duration": 86400,
                              })
 
         o = server_tap.Options()
@@ -107,6 +119,8 @@ class Config(unittest.TestCase):
                              "blur-usage": None,
                              "motd": None,
                              "websocket-protocol-options": [],
+                             "addrid-db": None,
+                             "generation-duration": 86400,
                              })
 
     def test_signal_error(self):
@@ -122,6 +136,8 @@ class Config(unittest.TestCase):
                              "blur-usage": None,
                              "motd": None,
                              "websocket-protocol-options": [],
+                             "addrid-db": None,
+                             "generation-duration": 86400,
                              })
 
     def test_usage_db(self):
@@ -137,6 +153,8 @@ class Config(unittest.TestCase):
                              "blur-usage": None,
                              "motd": None,
                              "websocket-protocol-options": [],
+                             "addrid-db": None,
+                             "generation-duration": 86400,
                              })
 
     def test_websocket_protocol_option_1(self):
@@ -152,6 +170,8 @@ class Config(unittest.TestCase):
                              "blur-usage": None,
                              "motd": None,
                              "websocket-protocol-options": [("foo", "bar")],
+                             "addrid-db": None,
+                             "generation-duration": 86400,
                              })
 
     def test_websocket_protocol_option_2(self):
@@ -171,6 +191,8 @@ class Config(unittest.TestCase):
                              "websocket-protocol-options": [("foo", "bar"),
                                                             ("baz", [1, "buz"]),
                                                             ],
+                             "addrid-db": None,
+                             "generation-duration": 86400,
                              })
 
     def test_websocket_protocol_option_errors(self):

--- a/src/wormhole_mailbox_server/test/test_connectiondb.py
+++ b/src/wormhole_mailbox_server/test/test_connectiondb.py
@@ -1,0 +1,116 @@
+from twisted.trial import unittest
+from ..database import create_channel_db
+from ..connections import ConnectionTable
+
+def get_messages(db, id):
+    #print(list(db.execute("SELECT * FROM `connection_messages`").fetchall()))
+    return [(row["name"], row["when"])
+            for row in db.execute("SELECT * FROM `connection_messages`"
+                                  " WHERE `id`=?", (id,)).fetchall()
+            ]
+
+class ConnectionDB(unittest.TestCase):
+    def test_connection_table(self):
+        db = create_channel_db(":memory:")
+        c = ConnectionTable(db)
+
+        c.clear()
+        rows = list(db.execute("SELECT * FROM connections").fetchall())
+        self.assertEqual(rows, [])
+        rows = list(db.execute("SELECT * FROM connection_messages").fetchall())
+        self.assertEqual(rows, [])
+
+        now = 1
+        aid1 = (1,3)
+        c1 = c.established(aid1, now)
+        rows = list(db.execute("SELECT * FROM connections").fetchall())
+        self.assertEqual(len(rows), 1)
+        id1 = rows[0]["id"]
+        expected = {
+            "id": id1,
+            "addrid_generation": aid1[0],
+            "addrid_counter": aid1[1],
+            "connected": now,
+            "side": None,
+            "implementation": None,
+            "version": None,
+            "active": now,
+            }
+        self.assertEqual(rows[0], expected)
+
+        now = 2
+        c1.add_message(now, "bind")
+        c1.bound("side1", ("impl", "v1"))
+        rows = list(db.execute("SELECT * FROM connections").fetchall())
+        expected["side"] = "side1"
+        expected["implementation"] = "impl"
+        expected["version"] = "v1"
+        expected["active"] = now
+        self.assertEqual(rows[0], expected)
+
+        expected_msgs = [("bind", now)]
+        self.assertEqual(get_messages(db, id1), expected_msgs)
+
+        now = 5
+        c1.add_message(now, "allocate")
+        expected["active"] = now
+        expected_msgs.append(("allocate", now))
+        rows = list(db.execute("SELECT * FROM connections").fetchall())
+        self.assertEqual(rows[0], expected)
+        self.assertEqual(get_messages(db, id1), expected_msgs)
+
+        now = 10
+        c1.add_message(now, "open")
+        expected["active"] = now
+        expected_msgs.append(("open", now))
+        rows = list(db.execute("SELECT * FROM connections").fetchall())
+        self.assertEqual(rows[0], expected)
+        self.assertEqual(get_messages(db, id1), expected_msgs)
+
+        now = 20
+        c1.add_message(now, "close")
+        expected["active"] = now
+        expected_msgs.append(("close", now))
+        rows = list(db.execute("SELECT * FROM connections").fetchall())
+        self.assertEqual(rows[0], expected)
+        self.assertEqual(get_messages(db, id1), expected_msgs)
+
+        now = 30
+        c1.lost()
+        expected_msgs = []
+        rows = list(db.execute("SELECT * FROM connections").fetchall())
+        self.assertEqual(rows, [])
+        self.assertEqual(get_messages(db, id1), expected_msgs)
+
+    def test_clear(self):
+        db = create_channel_db(":memory:")
+        c = ConnectionTable(db)
+
+        c.clear()
+        rows = list(db.execute("SELECT * FROM connections").fetchall())
+        self.assertEqual(rows, [])
+        rows = list(db.execute("SELECT * FROM connection_messages").fetchall())
+        self.assertEqual(rows, [])
+
+        now = 1
+        aid1 = (1,3)
+        c1 = c.established(aid1, now)
+        rows = list(db.execute("SELECT * FROM connections").fetchall())
+        self.assertEqual(len(rows), 1)
+        id1 = rows[0]["id"]
+        c1.add_message(2, "bind")
+        c1.add_message(3, "open")
+        c1.add_message(4, "add")
+        c1.add_message(5, "close")
+        rows = list(db.execute("SELECT * FROM connections").fetchall())
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(len(get_messages(db, id1)), 4)
+
+        c.clear()
+        rows = list(db.execute("SELECT * FROM connections").fetchall())
+        self.assertEqual(len(rows), 0)
+        self.assertEqual(len(get_messages(db, id1)), 0)
+
+
+
+

--- a/src/wormhole_mailbox_server/test/test_service.py
+++ b/src/wormhole_mailbox_server/test/test_service.py
@@ -9,25 +9,29 @@ class Service(unittest.TestCase):
         o.parseOptions([])
         cdb = object()
         udb = object()
+        aidb = object()
         r = mock.Mock()
         ws = object()
-        with mock.patch("wormhole_mailbox_server.server_tap.create_or_upgrade_channel_db", return_value=cdb) as ccdb:
-            with mock.patch("wormhole_mailbox_server.server_tap.create_or_upgrade_usage_db", return_value=udb) as ccub:
-                with mock.patch("wormhole_mailbox_server.server_tap.make_server", return_value=r) as ms:
-                    with mock.patch("wormhole_mailbox_server.server_tap.make_web_server", return_value=ws) as mws:
-                        s = server_tap.makeService(o)
-        self.assertEqual(ccdb.mock_calls, [mock.call("relay.sqlite")])
-        self.assertEqual(ccub.mock_calls, [])
+        with mock.patch("wormhole_mailbox_server.server_tap.create_or_upgrade_channel_db", return_value=cdb) as c_cdb:
+            with mock.patch("wormhole_mailbox_server.server_tap.create_or_upgrade_usage_db", return_value=udb) as c_udb:
+                with mock.patch("wormhole_mailbox_server.server_tap.create_or_upgrade_addrid_db", return_value=aidb) as c_aidb:
+                    with mock.patch("wormhole_mailbox_server.server_tap.make_server", return_value=r) as ms:
+                        with mock.patch("wormhole_mailbox_server.server_tap.make_web_server", return_value=ws) as mws:
+                            s = server_tap.makeService(o)
+        self.assertEqual(c_cdb.mock_calls, [mock.call("relay.sqlite")])
+        self.assertEqual(c_udb.mock_calls, [])
+        self.assertEqual(c_aidb.mock_calls, [])
         self.assertEqual(ms.mock_calls, [mock.call(cdb, allow_list=True,
                                                    advertise_version=None,
                                                    signal_error=None,
                                                    welcome_motd=None,
                                                    blur_usage=None,
                                                    usage_db=None,
+                                                   addrid_db=None,
                                                    )])
         self.assertEqual(mws.mock_calls, [mock.call(r, True, [])])
         self.assertIsInstance(s, MultiService)
-        self.assertEqual(len(r.mock_calls), 1) # setServiceParent
+        self.assertEqual(len(r.mock_calls), 3) # setServiceParent, check_addrid_generation, clear_connections
 
     def test_usagedb(self):
         o = server_tap.Options()
@@ -49,7 +53,37 @@ class Service(unittest.TestCase):
                                                    welcome_motd=None,
                                                    blur_usage=None,
                                                    usage_db=udb,
+                                                   addrid_db=None,
                                                    )])
         self.assertEqual(mws.mock_calls, [mock.call(r, True, [])])
         self.assertIsInstance(s, MultiService)
-        self.assertEqual(len(r.mock_calls), 1) # setServiceParent
+        self.assertEqual(len(r.mock_calls), 3) # setServiceParent, check_addrid_generation, clear_connections
+
+    def test_addriddb(self):
+        o = server_tap.Options()
+        o.parseOptions(["--addrid-db=addresses.sqlite"])
+        cdb = object()
+        udb = object()
+        aidb = object()
+        r = mock.Mock()
+        ws = object()
+        with mock.patch("wormhole_mailbox_server.server_tap.create_or_upgrade_channel_db", return_value=cdb) as ccdb:
+            with mock.patch("wormhole_mailbox_server.server_tap.create_or_upgrade_usage_db", return_value=udb) as ccub:
+                with mock.patch("wormhole_mailbox_server.server_tap.create_or_upgrade_addrid_db", return_value=aidb) as c_aidb:
+                    with mock.patch("wormhole_mailbox_server.server_tap.make_server", return_value=r) as ms:
+                        with mock.patch("wormhole_mailbox_server.server_tap.make_web_server", return_value=ws) as mws:
+                            s = server_tap.makeService(o)
+        self.assertEqual(ccdb.mock_calls, [mock.call("relay.sqlite")])
+        self.assertEqual(ccub.mock_calls, [])
+        self.assertEqual(c_aidb.mock_calls, [mock.call("addresses.sqlite")])
+        self.assertEqual(ms.mock_calls, [mock.call(cdb, allow_list=True,
+                                                   advertise_version=None,
+                                                   signal_error=None,
+                                                   welcome_motd=None,
+                                                   blur_usage=None,
+                                                   usage_db=None,
+                                                   addrid_db=aidb,
+                                                   )])
+        self.assertEqual(mws.mock_calls, [mock.call(r, True, [])])
+        self.assertIsInstance(s, MultiService)
+        self.assertEqual(len(r.mock_calls), 3) # setServiceParent, check_addrid_generation, clear_connections

--- a/src/wormhole_mailbox_server/test/test_websocket.py
+++ b/src/wormhole_mailbox_server/test/test_websocket.py
@@ -3,6 +3,7 @@ from twisted.trial import unittest
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.address import IPv4Address
 from ..server_websocket import WebSocketServerFactory
+from ..connections import ConnectionTable
 from autobahn.twisted.testing import create_pumper, create_memory_agent, MemoryReactorClock
 from autobahn.twisted.websocket import WebSocketClientProtocol
 
@@ -13,6 +14,9 @@ class FakeServer:
     WebSocket server.
 
     """
+    def __init__(self):
+        self._connection_table = ConnectionTable(None)
+
     def get_welcome(self):
         return {
             "motd": "fake message of the day"
@@ -20,6 +24,13 @@ class FakeServer:
 
     def get_log_requests(self):
         return False
+
+    def get_address_id(self, peer_type, peer_host):
+        return None
+
+    def connection_established(self, address_id, now):
+        c = self._connection_table.established(address_id, now)
+        return c
 
 
 class WebSocket(unittest.TestCase):

--- a/src/wormhole_mailbox_server/util.py
+++ b/src/wormhole_mailbox_server/util.py
@@ -24,3 +24,8 @@ def bytes_to_dict(b):
     d = json.loads(b.decode("utf-8"))
     assert isinstance(d, dict)
     return d
+
+def str_or_none(data):
+    if data is None:
+        return data
+    return str(data)


### PR DESCRIPTION
This adds new code and database tables to help with server operations. One table assigns opaque "address IDs" to each client's IP address, to serve as a more-privacy-preserving standin for that IP address in logs and other tables. The mapping is discarded every 24 hours (by default). It also adds a "current connections" table to the main database, which manages a list of current connections, their address IDs, and what messages they've submitted.

This is all in support of some separate dashboard tools, in a separate repository, which will have a read-only view of the mailbox server's database.

refs #14 (this will support a better client-version-update dashboard)